### PR TITLE
add FBE_USING_STD_VECTOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ add_subdirectory("modules/cpp-optparse")
 # Link libraries
 #list(APPEND LINKLIBS cppcommon)
 
+option(USING_STD_VECTOR "using std vector" OFF)
+if (USING_STD_VECTOR)
+  add_definitions(-DUSING_STD_VECTOR)
+endif()
+
 # System directories
 #include_directories("${CMAKE_CURRENT_SOURCE_DIR}/CppCommon")
 include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ add_subdirectory("modules/cpp-optparse")
 # Link libraries
 #list(APPEND LINKLIBS cppcommon)
 
-option(USING_STD_VECTOR "using std vector" OFF)
-if (USING_STD_VECTOR)
+option(FBE_USING_STD_VECTOR "using std vector" OFF)
+if (FBE_USING_STD_VECTOR)
   add_definitions(-DUSING_STD_VECTOR)
 endif()
 

--- a/proto/extra_ptr.cpp
+++ b/proto/extra_ptr.cpp
@@ -16,7 +16,7 @@ Info::Info()
     , extras1()
 {}
 
-Info::Info(const stdb::memory::string& arg_info, std::unique_ptr<::extra::Extra> arg_extra, stdb::container::stdb_vector<std::unique_ptr<::extra::Extra>> arg_extras, stdb::container::stdb_vector<std::unique_ptr<::extra::Extra>> arg_extras1)
+Info::Info(const stdb::memory::string& arg_info, std::unique_ptr<::extra::Extra> arg_extra, FastVec<std::unique_ptr<::extra::Extra>> arg_extras, FastVec<std::unique_ptr<::extra::Extra>> arg_extras1)
     : info(arg_info)
     , extra(arg_extra.release())
     , extras()
@@ -24,10 +24,18 @@ Info::Info(const stdb::memory::string& arg_info, std::unique_ptr<::extra::Extra>
 {
     extras.reserve(arg_extras.size());
     for (auto& it : arg_extras)
+        #if defined(USING_STD_VECTOR)
+        extras.emplace_back(it.release());
+        #else
         extras.emplace_back<Safety::Unsafe>(it.release());
+        #endif
     extras1.reserve(arg_extras1.size());
     for (auto& it : arg_extras1)
+        #if defined(USING_STD_VECTOR)
+        extras1.emplace_back(it.release());
+        #else
         extras1.emplace_back<Safety::Unsafe>(it.release());
+        #endif
 }
 
 Info::Info([[maybe_unused]] Info&& other) noexcept
@@ -144,7 +152,7 @@ Extra::Extra()
     , infopl()
 {}
 
-Extra::Extra(int64_t arg_num, const stdb::memory::string& arg_data, std::unique_ptr<::extra::Info> arg_info, std::unique_ptr<::extra::Info> arg_info2, ::extra::Info&& arg_info3, stdb::container::stdb_vector<::extra::Info> arg_infov, stdb::container::stdb_vector<std::unique_ptr<::extra::Info>> arg_infopv, std::list<::extra::Info> arg_infol, std::list<std::unique_ptr<::extra::Info>> arg_infopl)
+Extra::Extra(int64_t arg_num, const stdb::memory::string& arg_data, std::unique_ptr<::extra::Info> arg_info, std::unique_ptr<::extra::Info> arg_info2, ::extra::Info&& arg_info3, FastVec<::extra::Info> arg_infov, FastVec<std::unique_ptr<::extra::Info>> arg_infopv, std::list<::extra::Info> arg_infol, std::list<std::unique_ptr<::extra::Info>> arg_infopl)
     : num(arg_num)
     , data(arg_data)
     , info(arg_info.release())
@@ -157,7 +165,11 @@ Extra::Extra(int64_t arg_num, const stdb::memory::string& arg_data, std::unique_
 {
     infopv.reserve(arg_infopv.size());
     for (auto& it : arg_infopv)
+        #if defined(USING_STD_VECTOR)
+        infopv.emplace_back(it.release());
+        #else
         infopv.emplace_back<Safety::Unsafe>(it.release());
+        #endif
     for (auto& it : arg_infopl)
         infopl.emplace_back(it.release());
 }

--- a/proto/extra_ptr.h
+++ b/proto/extra_ptr.h
@@ -39,13 +39,13 @@ struct Info : FBE::Base
 {
     stdb::memory::string info;
     ::extra::Extra* extra;
-    stdb::container::stdb_vector<::extra::Extra*> extras;
-    stdb::container::stdb_vector<::extra::Extra*> extras1;
+    FastVec<::extra::Extra*> extras;
+    FastVec<::extra::Extra*> extras1;
 
     size_t fbe_type() const noexcept { return 1; }
 
     Info();
-    Info(const stdb::memory::string& arg_info, std::unique_ptr<::extra::Extra> arg_extra, stdb::container::stdb_vector<std::unique_ptr<::extra::Extra>> arg_extras, stdb::container::stdb_vector<std::unique_ptr<::extra::Extra>> arg_extras1);
+    Info(const stdb::memory::string& arg_info, std::unique_ptr<::extra::Extra> arg_extra, FastVec<std::unique_ptr<::extra::Extra>> arg_extras, FastVec<std::unique_ptr<::extra::Extra>> arg_extras1);
     Info(const Info& other) = default;
     Info(Info&& other) noexcept;
     ~Info() override;
@@ -94,15 +94,15 @@ struct Extra : FBE::Base
     ::extra::Info* info;
     ::extra::Info* info2;
     ::extra::Info info3;
-    stdb::container::stdb_vector<::extra::Info> infov;
-    stdb::container::stdb_vector<::extra::Info*> infopv;
+    FastVec<::extra::Info> infov;
+    FastVec<::extra::Info*> infopv;
     std::list<::extra::Info> infol;
     std::list<::extra::Info*> infopl;
 
     size_t fbe_type() const noexcept { return 2; }
 
     Extra();
-    Extra(int64_t arg_num, const stdb::memory::string& arg_data, std::unique_ptr<::extra::Info> arg_info, std::unique_ptr<::extra::Info> arg_info2, ::extra::Info&& arg_info3, stdb::container::stdb_vector<::extra::Info> arg_infov, stdb::container::stdb_vector<std::unique_ptr<::extra::Info>> arg_infopv, std::list<::extra::Info> arg_infol, std::list<std::unique_ptr<::extra::Info>> arg_infopl);
+    Extra(int64_t arg_num, const stdb::memory::string& arg_data, std::unique_ptr<::extra::Info> arg_info, std::unique_ptr<::extra::Info> arg_info2, ::extra::Info&& arg_info3, FastVec<::extra::Info> arg_infov, FastVec<std::unique_ptr<::extra::Info>> arg_infopv, std::list<::extra::Info> arg_infol, std::list<std::unique_ptr<::extra::Info>> arg_infopl);
     Extra(const Extra& other) = default;
     Extra(Extra&& other) noexcept;
     ~Extra() override;

--- a/proto/fbe.cpp
+++ b/proto/fbe.cpp
@@ -356,7 +356,7 @@ void FBEBuffer::attach(const void* data, size_t size, size_t offset)
     _offset = offset;
 }
 
-void FBEBuffer::attach(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset)
+void FBEBuffer::attach(const FastVec<uint8_t>& buffer, size_t offset)
 {
     assert((buffer.data() != nullptr) && "Invalid buffer!");
     if (buffer.data() == nullptr)
@@ -387,7 +387,7 @@ void FBEBuffer::clone(const void* data, size_t size, size_t offset)
     _offset = offset;
 }
 
-void FBEBuffer::clone(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset)
+void FBEBuffer::clone(const FastVec<uint8_t>& buffer, size_t offset)
 {
     assert((offset <= buffer.size()) && "Invalid offset!");
     if (offset > buffer.size())

--- a/proto/fbe_custom_models.h
+++ b/proto/fbe_custom_models.h
@@ -126,13 +126,13 @@ public:
     template <size_t S>
     void set(const std::array<TStruct*, S>& values) noexcept;
 
-    // Get the array as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<TStruct>& values) const noexcept;
-    void get(stdb::container::stdb_vector<TStruct*>& values) const noexcept;
+    // Get the array as FastVec
+    void get(FastVec<TStruct>& values) const noexcept;
+    void get(FastVec<TStruct*>& values) const noexcept;
 
-    // Set the array as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<TStruct>& values) noexcept;
-    void set(const stdb::container::stdb_vector<TStruct*>& values) noexcept;
+    // Set the array as FastVec
+    void set(const FastVec<TStruct>& values) noexcept;
+    void set(const FastVec<TStruct*>& values) noexcept;
 
     // Get the array as pmr::vector
     void get(pmr::vector<TStruct>& values) const noexcept;
@@ -179,9 +179,9 @@ public:
     // Check if the vector is valid
     bool verify() const noexcept;
 
-    // Get the vector as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<TStruct>& values) const noexcept;
-    void get(stdb::container::stdb_vector<TStruct*>& values) const noexcept;
+    // Get the vector as FastVec
+    void get(FastVec<TStruct>& values) const noexcept;
+    void get(FastVec<TStruct*>& values) const noexcept;
     // Get the vector as std::list
     void get(std::list<TStruct>& values) const noexcept;
     void get(std::list<TStruct*>& values) const noexcept;
@@ -189,9 +189,9 @@ public:
     void get(std::set<TStruct>& values) const noexcept;
     void get(std::set<TStruct*>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<TStruct>& values) noexcept;
-    void set(const stdb::container::stdb_vector<TStruct*>& values) noexcept;
+    // Set the vector as FastVec
+    void set(const FastVec<TStruct>& values) noexcept;
+    void set(const FastVec<TStruct*>& values) noexcept;
     // Set the vector as std::list
     void set(const std::list<TStruct>& values) noexcept;
     void set(const std::list<TStruct*>& values) noexcept;

--- a/proto/fbe_custom_models.inl
+++ b/proto/fbe_custom_models.inl
@@ -167,7 +167,7 @@ inline void FieldModelCustomArray<T, TStruct, N>::set(const std::array<TStruct*,
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vector<TStruct>& values) const noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::get(FastVec<TStruct>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -177,13 +177,17 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vect
     {
         TStruct value;
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vector<TStruct*>& values) const noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::get(FastVec<TStruct*>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -193,13 +197,17 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vect
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::stdb_vector<TStruct>& values) noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::set(const FastVec<TStruct>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -214,7 +222,7 @@ inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::std
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::stdb_vector<TStruct*>& values) noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::set(const FastVec<TStruct*>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -239,7 +247,11 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(pmr::vector<TStruct>& valu
     {
         TStruct value;
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
         values.emplace_back(std::move(value));
+        #else
+        values.emplace_back(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -255,7 +267,11 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(pmr::vector<TStruct*>& val
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
         values.emplace_back(std::move(value));
+        #else
+        values.emplace_back(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -396,7 +412,7 @@ inline bool FieldModelCustomVector<T, TStruct>::verify() const noexcept
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector<TStruct>& values) const noexcept
+inline void FieldModelCustomVector<T, TStruct>::get(FastVec<TStruct>& values) const noexcept
 {
     values.clear();
 
@@ -411,13 +427,17 @@ inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector
     {
         TStruct value = TStruct();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector<TStruct*>& values) const noexcept
+inline void FieldModelCustomVector<T, TStruct>::get(FastVec<TStruct*>& values) const noexcept
 {
     values.clear();
 
@@ -432,7 +452,11 @@ inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -514,7 +538,7 @@ inline void FieldModelCustomVector<T, TStruct>::get(std::set<TStruct*>& values) 
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_vector<TStruct>& values) noexcept
+inline void FieldModelCustomVector<T, TStruct>::set(const FastVec<TStruct>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -529,7 +553,7 @@ inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_vector<TStruct*>& values) noexcept
+inline void FieldModelCustomVector<T, TStruct>::set(const FastVec<TStruct*>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -619,7 +643,11 @@ inline void FieldModelCustomVector<T, TStruct>::get(pmr::vector<TStruct>& values
     {
         TStruct value = TStruct();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
         values.emplace_back(std::move(value));
+        #else
+        values.emplace_back(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -640,7 +668,11 @@ inline void FieldModelCustomVector<T, TStruct>::get(pmr::vector<TStruct*>& value
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
         values.emplace_back(value);
+        #else
+        values.emplace_back(value);
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }

--- a/proto/fbe_final_models.cpp
+++ b/proto/fbe_final_models.cpp
@@ -309,7 +309,7 @@ size_t FinalModel<buffer_t>::get(void* data, size_t size) const noexcept
     return 4 + fbe_bytes_size;
 }
 
-size_t FinalModel<buffer_t>::get(stdb::container::stdb_vector<uint8_t>& value) const noexcept
+size_t FinalModel<buffer_t>::get(FastVec<uint8_t>& value) const noexcept
 {
     value.clear();
 

--- a/proto/fbe_final_models.h
+++ b/proto/fbe_final_models.h
@@ -180,7 +180,7 @@ public:
     size_t fbe_allocation_size(const uint8_t (&data)[N]) const noexcept { return 4 + N; }
     template <size_t N>
     size_t fbe_allocation_size(const std::array<uint8_t, N>& data) const noexcept { return 4 + N; }
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<uint8_t>& value) const noexcept { return 4 + value.size(); }
+    size_t fbe_allocation_size(const FastVec<uint8_t>& value) const noexcept { return 4 + value.size(); }
     size_t fbe_allocation_size(const buffer_t& value) const noexcept { return 4 + value.size(); }
 
     // Get the field offset
@@ -205,7 +205,7 @@ public:
     template <size_t N>
     size_t get(std::array<uint8_t, N>& data) const noexcept { return get(data.data(), data.size()); }
     // Get the bytes value
-    size_t get(stdb::container::stdb_vector<uint8_t>& value) const noexcept;
+    size_t get(FastVec<uint8_t>& value) const noexcept;
     // Get the bytes value
     size_t get(buffer_t& value) const noexcept { return get(value.buffer()); }
 
@@ -218,7 +218,7 @@ public:
     template <size_t N>
     size_t set(const std::array<uint8_t, N>& data) { return set(data.data(), data.size()); }
     // Set the bytes value
-    size_t set(const stdb::container::stdb_vector<uint8_t>& value) { return set(value.data(), value.size()); }
+    size_t set(const FastVec<uint8_t>& value) { return set(value.data(), value.size()); }
     // Set the bytes value
     size_t set(const buffer_t& value) { return set(value.buffer()); }
 
@@ -337,7 +337,7 @@ public:
     size_t fbe_allocation_size(const T (&values)[S]) const noexcept;
     template <size_t S>
     size_t fbe_allocation_size(const std::array<T, S>& values) const noexcept;
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept;
+    size_t fbe_allocation_size(const FastVec<T>& values) const noexcept;
 
     // Get the field offset
     size_t fbe_offset() const noexcept { return _offset; }
@@ -358,8 +358,8 @@ public:
     // Get the array as std::array
     template <size_t S>
     size_t get(std::array<T, S>& values) const noexcept;
-    // Get the array as stdb::container::stdb_vector
-    size_t get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the array as FastVec
+    size_t get(FastVec<T>& values) const noexcept;
 
     // Set the array as C-array
     template <size_t S>
@@ -367,8 +367,8 @@ public:
     // Set the array as std::array
     template <size_t S>
     size_t set(const std::array<T, S>& values) noexcept;
-    // Set the array as stdb::container::stdb_vector
-    size_t set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the array as FastVec
+    size_t set(const FastVec<T>& values) noexcept;
 
 private:
     FBEBuffer& _buffer;
@@ -383,7 +383,7 @@ public:
     FinalModelVector(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
 
     // Get the allocation size
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept;
+    size_t fbe_allocation_size(const FastVec<T>& values) const noexcept;
     size_t fbe_allocation_size(const std::list<T>& values) const noexcept;
     size_t fbe_allocation_size(const std::set<T>& values) const noexcept;
 
@@ -400,15 +400,15 @@ public:
     // Check if the vector is valid
     size_t verify() const noexcept;
 
-    // Get the vector as stdb::container::stdb_vector
-    size_t get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the vector as FastVec
+    size_t get(FastVec<T>& values) const noexcept;
     // Get the vector as std::list
     size_t get(std::list<T>& values) const noexcept;
     // Get the vector as std::set
     size_t get(std::set<T>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    size_t set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the vector as FastVec
+    size_t set(const FastVec<T>& values) noexcept;
     // Set the vector as std::list
     size_t set(const std::list<T>& values) noexcept;
     // Set the vector as std::set

--- a/proto/fbe_final_models.inl
+++ b/proto/fbe_final_models.inl
@@ -127,7 +127,7 @@ inline size_t FinalModelArray<T, N>::fbe_allocation_size(const std::array<T, S>&
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelArray<T, N>::fbe_allocation_size(const FastVec<T>& values) const noexcept
 {
     size_t size = 0;
     FinalModel<T> fbe_model(_buffer, fbe_offset());
@@ -194,7 +194,7 @@ inline size_t FinalModelArray<T, N>::get(std::array<T, S>& values) const noexcep
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelArray<T, N>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -210,7 +210,11 @@ inline size_t FinalModelArray<T, N>::get(stdb::container::stdb_vector<T>& values
     {
         T value = T();
         size_t offset = fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(offset);
         size += offset;
     }
@@ -256,7 +260,7 @@ inline size_t FinalModelArray<T, N>::set(const std::array<T, S>& values) noexcep
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline size_t FinalModelArray<T, N>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset()) > _buffer.size())
@@ -274,7 +278,7 @@ inline size_t FinalModelArray<T, N>::set(const stdb::container::stdb_vector<T>& 
 }
 
 template <typename T>
-inline size_t FinalModelVector<T>::fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelVector<T>::fbe_allocation_size(const FastVec<T>& values) const noexcept
 {
     size_t size = 4;
     FinalModel<T> fbe_model(_buffer, fbe_offset() + 4);
@@ -325,7 +329,7 @@ inline size_t FinalModelVector<T>::verify() const noexcept
 }
 
 template <typename T>
-inline size_t FinalModelVector<T>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelVector<T>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -345,7 +349,11 @@ inline size_t FinalModelVector<T>::get(stdb::container::stdb_vector<T>& values) 
     {
         T value = T();
         size_t offset = fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(offset);
         size += offset;
     }
@@ -405,7 +413,7 @@ inline size_t FinalModelVector<T>::get(std::set<T>& values) const noexcept
 }
 
 template <typename T>
-inline size_t FinalModelVector<T>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline size_t FinalModelVector<T>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + 4) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + 4) > _buffer.size())

--- a/proto/fbe_json.h
+++ b/proto/fbe_json.h
@@ -329,9 +329,9 @@ struct ValueWriter<TWriter, std::array<T, N>>
 };
 
 template <class TWriter, typename T>
-struct ValueWriter<TWriter, stdb::container::stdb_vector<T>>
+struct ValueWriter<TWriter, FastVec<T>>
 {
-    static bool to_json(TWriter& writer, const stdb::container::stdb_vector<T>& values, bool scope = true)
+    static bool to_json(TWriter& writer, const FastVec<T>& values, bool scope = true)
     {
         writer.StartArray();
         for (const auto& value : values)
@@ -892,9 +892,9 @@ struct ValueReader<TJson, std::array<T, N>>
 };
 
 template <class TJson, typename T>
-struct ValueReader<TJson, stdb::container::stdb_vector<T>>
+struct ValueReader<TJson, FastVec<T>>
 {
-    static bool from_json(const TJson& json, stdb::container::stdb_vector<T>& values)
+    static bool from_json(const TJson& json, FastVec<T>& values)
     {
         values.clear();
 
@@ -909,7 +909,11 @@ struct ValueReader<TJson, stdb::container::stdb_vector<T>>
             T temp = T();
             if (!FBE::JSON::from_json(item, temp))
                 return false;
+            #if defined(USING_STD_VECTOR)
+            values.emplace_back(temp);
+            #else
             values.template emplace_back<Safety::Unsafe>(temp);
+            #endif
         }
         return true;
     }

--- a/proto/fbe_models.cpp
+++ b/proto/fbe_models.cpp
@@ -322,7 +322,7 @@ size_t FieldModel<buffer_t>::get(void* data, size_t size) const noexcept
     return result;
 }
 
-void FieldModel<buffer_t>::get(stdb::container::stdb_vector<uint8_t>& value) const noexcept
+void FieldModel<buffer_t>::get(FastVec<uint8_t>& value) const noexcept
 {
     value.clear();
 

--- a/proto/fbe_models.h
+++ b/proto/fbe_models.h
@@ -186,7 +186,7 @@ public:
     template <size_t N>
     size_t get(std::array<uint8_t, N>& data) const noexcept { return get(data.data(), data.size()); }
     // Get the bytes value
-    void get(stdb::container::stdb_vector<uint8_t>& value) const noexcept;
+    void get(FastVec<uint8_t>& value) const noexcept;
     // Get the bytes value
     void get(buffer_t& value) const noexcept { get(value.buffer()); }
 
@@ -199,7 +199,7 @@ public:
     template <size_t N>
     void set(const std::array<uint8_t, N>& data) { set(data.data(), data.size()); }
     // Set the bytes value
-    void set(const stdb::container::stdb_vector<uint8_t>& value) { set(value.data(), value.size()); }
+    void set(const FastVec<uint8_t>& value) { set(value.data(), value.size()); }
     // Set the bytes value
     void set(const buffer_t& value) { set(value.buffer()); }
 
@@ -452,8 +452,8 @@ public:
     // Get the array as std::array
     template <size_t S>
     void get(std::array<T, S>& values) const noexcept;
-    // Get the array as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the array as FastVec
+    void get(FastVec<T>& values) const noexcept;
 
     // Set the array as C-array
     template <size_t S>
@@ -461,8 +461,8 @@ public:
     // Set the array as std::array
     template <size_t S>
     void set(const std::array<T, S>& values) noexcept;
-    // Set the array as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the array as FastVec
+    void set(const FastVec<T>& values) noexcept;
 
 private:
     FBEBuffer& _buffer;
@@ -503,8 +503,8 @@ public:
     // Check if the vector is valid
     bool verify() const noexcept;
 
-    // Get the vector as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the vector as FastVec
+    void get(FastVec<T>& values) const noexcept;
     // Get the vector as std::list
     void get(std::list<T>& values) const noexcept;
     // Get the vector as std::set
@@ -517,8 +517,8 @@ public:
     // Get the vector as pmr::set
     void get(pmr::set<T>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the vector as FastVec
+    void set(const FastVec<T>& values) noexcept;
     // Set the vector as std::list
     void set(const std::list<T>& values) noexcept;
     // Set the vector as std::set

--- a/proto/fbe_models.inl
+++ b/proto/fbe_models.inl
@@ -236,7 +236,7 @@ inline void FieldModelArray<T, N>::get(std::array<T, S>& values) const noexcept
 }
 
 template <typename T, size_t N>
-inline void FieldModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline void FieldModelArray<T, N>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -246,7 +246,11 @@ inline void FieldModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) 
     {
         T value = T();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -284,7 +288,7 @@ inline void FieldModelArray<T, N>::set(const std::array<T, S>& values) noexcept
 }
 
 template <typename T, size_t N>
-inline void FieldModelArray<T, N>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline void FieldModelArray<T, N>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -404,7 +408,7 @@ inline bool FieldModelVector<T>::verify() const noexcept
 }
 
 template <typename T>
-inline void FieldModelVector<T>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline void FieldModelVector<T>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -419,7 +423,11 @@ inline void FieldModelVector<T>::get(stdb::container::stdb_vector<T>& values) co
     {
         T value = T();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -522,7 +530,7 @@ inline void FieldModelVector<T>::get(pmr::set<T>& values) const noexcept
 }
 
 template <typename T>
-inline void FieldModelVector<T>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline void FieldModelVector<T>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())

--- a/proto/pkg_ptr.cpp
+++ b/proto/pkg_ptr.cpp
@@ -94,7 +94,7 @@ Detail::Detail()
     , extram()
 {}
 
-Detail::Detail(stdb::container::stdb_vector<::osa::Extra> arg_extrav, std::map<int32_t, ::osa::Extra> arg_extram)
+Detail::Detail(FastVec<::osa::Extra> arg_extrav, std::map<int32_t, ::osa::Extra> arg_extram)
     : extrav(std::move(arg_extrav))
     , extram(std::move(arg_extram))
 {}

--- a/proto/pkg_ptr.h
+++ b/proto/pkg_ptr.h
@@ -88,13 +88,13 @@ namespace pkg {
 
 struct Detail : FBE::Base
 {
-    stdb::container::stdb_vector<::osa::Extra> extrav;
+    FastVec<::osa::Extra> extrav;
     std::map<int32_t, ::osa::Extra> extram;
 
     size_t fbe_type() const noexcept { return 2; }
 
     Detail();
-    Detail(stdb::container::stdb_vector<::osa::Extra> arg_extrav, std::map<int32_t, ::osa::Extra> arg_extram);
+    Detail(FastVec<::osa::Extra> arg_extrav, std::map<int32_t, ::osa::Extra> arg_extram);
     Detail(const Detail& other) = default;
     Detail(Detail&& other) noexcept;
     ~Detail() override;

--- a/proto/proto.cpp
+++ b/proto/proto.cpp
@@ -190,7 +190,7 @@ Account::Account()
     , orders()
 {}
 
-Account::Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::proto::State& arg_state, const ::proto::Balance& arg_wallet, const std::optional<::proto::Balance>& arg_asset, const stdb::container::stdb_vector<::proto::Order>& arg_orders)
+Account::Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::proto::State& arg_state, const ::proto::Balance& arg_wallet, const std::optional<::proto::Balance>& arg_asset, const FastVec<::proto::Order>& arg_orders)
     : id(arg_id)
     , name(arg_name)
     , state(arg_state)

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -204,12 +204,12 @@ struct Account
     ::proto::State state;
     ::proto::Balance wallet;
     std::optional<::proto::Balance> asset;
-    stdb::container::stdb_vector<::proto::Order> orders;
+    FastVec<::proto::Order> orders;
 
     size_t fbe_type() const noexcept { return 3; }
 
     Account();
-    Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::proto::State& arg_state, const ::proto::Balance& arg_wallet, const std::optional<::proto::Balance>& arg_asset, const stdb::container::stdb_vector<::proto::Order>& arg_orders);
+    Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::proto::State& arg_state, const ::proto::Balance& arg_wallet, const std::optional<::proto::Balance>& arg_asset, const FastVec<::proto::Order>& arg_orders);
     Account(const Account& other) = default;
     Account(Account&& other) = default;
     ~Account() = default;

--- a/proto/protoex.cpp
+++ b/proto/protoex.cpp
@@ -212,7 +212,7 @@ Account::Account()
     , orders()
 {}
 
-Account::Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::protoex::StateEx& arg_state, const ::protoex::Balance& arg_wallet, const std::optional<::protoex::Balance>& arg_asset, const stdb::container::stdb_vector<::protoex::Order>& arg_orders)
+Account::Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::protoex::StateEx& arg_state, const ::protoex::Balance& arg_wallet, const std::optional<::protoex::Balance>& arg_asset, const FastVec<::protoex::Order>& arg_orders)
     : id(arg_id)
     , name(arg_name)
     , state(arg_state)

--- a/proto/protoex.h
+++ b/proto/protoex.h
@@ -212,12 +212,12 @@ struct Account
     ::protoex::StateEx state;
     ::protoex::Balance wallet;
     std::optional<::protoex::Balance> asset;
-    stdb::container::stdb_vector<::protoex::Order> orders;
+    FastVec<::protoex::Order> orders;
 
     size_t fbe_type() const noexcept { return 3; }
 
     Account();
-    Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::protoex::StateEx& arg_state, const ::protoex::Balance& arg_wallet, const std::optional<::protoex::Balance>& arg_asset, const stdb::container::stdb_vector<::protoex::Order>& arg_orders);
+    Account(int32_t arg_id, const stdb::memory::string& arg_name, const ::protoex::StateEx& arg_state, const ::protoex::Balance& arg_wallet, const std::optional<::protoex::Balance>& arg_asset, const FastVec<::protoex::Order>& arg_orders);
     Account(const Account& other) = default;
     Account(Account&& other) = default;
     ~Account() = default;

--- a/proto/sa_ptr.cpp
+++ b/proto/sa_ptr.cpp
@@ -202,7 +202,7 @@ Complex::Complex()
     , nums()
 {}
 
-Complex::Complex(const stdb::memory::string& arg_name, std::optional<::sa::Sex> arg_sex, std::optional<::sa::MyFLags> arg_flag, std::optional<::sa::Extra> arg_extra, stdb::container::stdb_vector<int64_t> arg_nums)
+Complex::Complex(const stdb::memory::string& arg_name, std::optional<::sa::Sex> arg_sex, std::optional<::sa::MyFLags> arg_flag, std::optional<::sa::Extra> arg_extra, FastVec<int64_t> arg_nums)
     : name(arg_name)
     , sex()
     , flag()

--- a/proto/sa_ptr.h
+++ b/proto/sa_ptr.h
@@ -172,12 +172,12 @@ struct Complex : FBE::Base
     std::optional<::sa::Sex> sex;
     std::optional<::sa::MyFLags> flag;
     std::optional<::sa::Extra> extra;
-    stdb::container::stdb_vector<int64_t> nums;
+    FastVec<int64_t> nums;
 
     size_t fbe_type() const noexcept { return 3; }
 
     Complex();
-    Complex(const stdb::memory::string& arg_name, std::optional<::sa::Sex> arg_sex, std::optional<::sa::MyFLags> arg_flag, std::optional<::sa::Extra> arg_extra, stdb::container::stdb_vector<int64_t> arg_nums);
+    Complex(const stdb::memory::string& arg_name, std::optional<::sa::Sex> arg_sex, std::optional<::sa::MyFLags> arg_flag, std::optional<::sa::Extra> arg_extra, FastVec<int64_t> arg_nums);
     Complex(const Complex& other) = default;
     Complex(Complex&& other) noexcept;
     ~Complex() override;

--- a/proto/simple_ptr.cpp
+++ b/proto/simple_ptr.cpp
@@ -19,7 +19,7 @@ Simple::Simple()
     , sm()
 {}
 
-Simple::Simple(const stdb::memory::string& arg_info, std::unique_ptr<::simple::Simple> arg_simple, int32_t arg_depth, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>> arg_spv, stdb::container::stdb_vector<::simple::Simple> arg_sv, std::map<int32_t, std::unique_ptr<::simple::Simple>> arg_spm, std::map<int32_t, ::simple::Simple> arg_sm)
+Simple::Simple(const stdb::memory::string& arg_info, std::unique_ptr<::simple::Simple> arg_simple, int32_t arg_depth, FastVec<std::unique_ptr<::simple::Simple>> arg_spv, FastVec<::simple::Simple> arg_sv, std::map<int32_t, std::unique_ptr<::simple::Simple>> arg_spm, std::map<int32_t, ::simple::Simple> arg_sm)
     : info(arg_info)
     , simple(arg_simple.release())
     , depth(arg_depth)
@@ -30,7 +30,11 @@ Simple::Simple(const stdb::memory::string& arg_info, std::unique_ptr<::simple::S
 {
     spv.reserve(arg_spv.size());
     for (auto& it : arg_spv)
+        #if defined(USING_STD_VECTOR)
+        spv.emplace_back(it.release());
+        #else
         spv.emplace_back<Safety::Unsafe>(it.release());
+        #endif
     for (auto& it: arg_spm)
         spm.emplace(it.first, it.second.release());
 }

--- a/proto/simple_ptr.h
+++ b/proto/simple_ptr.h
@@ -38,15 +38,15 @@ struct Simple : FBE::Base
     stdb::memory::string info;
     ::simple::Simple* simple;
     int32_t depth;
-    stdb::container::stdb_vector<::simple::Simple*> spv;
-    stdb::container::stdb_vector<::simple::Simple> sv;
+    FastVec<::simple::Simple*> spv;
+    FastVec<::simple::Simple> sv;
     std::map<int32_t, ::simple::Simple*> spm;
     std::map<int32_t, ::simple::Simple> sm;
 
     size_t fbe_type() const noexcept { return 1; }
 
     Simple();
-    Simple(const stdb::memory::string& arg_info, std::unique_ptr<::simple::Simple> arg_simple, int32_t arg_depth, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>> arg_spv, stdb::container::stdb_vector<::simple::Simple> arg_sv, std::map<int32_t, std::unique_ptr<::simple::Simple>> arg_spm, std::map<int32_t, ::simple::Simple> arg_sm);
+    Simple(const stdb::memory::string& arg_info, std::unique_ptr<::simple::Simple> arg_simple, int32_t arg_depth, FastVec<std::unique_ptr<::simple::Simple>> arg_spv, FastVec<::simple::Simple> arg_sv, std::map<int32_t, std::unique_ptr<::simple::Simple>> arg_spm, std::map<int32_t, ::simple::Simple> arg_sm);
     Simple(const Simple& other) = default;
     Simple(Simple&& other) noexcept;
     ~Simple() override;

--- a/proto/template_variant_ptr.cpp
+++ b/proto/template_variant_ptr.cpp
@@ -16,7 +16,7 @@ Line::Line()
     , vo()
 {}
 
-Line::Line(::variants::V&& arg_v, stdb::container::stdb_vector<::variants::V> arg_vv, std::unordered_map<stdb::memory::string, ::variants::V> arg_vm, std::optional<::variants::V> arg_vo)
+Line::Line(::variants::V&& arg_v, FastVec<::variants::V> arg_vv, std::unordered_map<stdb::memory::string, ::variants::V> arg_vm, std::optional<::variants::V> arg_vo)
     : v(std::move(arg_v))
     , vv(std::move(arg_vv))
     , vm(std::move(arg_vm))

--- a/proto/template_variant_ptr.h
+++ b/proto/template_variant_ptr.h
@@ -41,14 +41,14 @@ namespace template_variant {
 struct Line : FBE::Base
 {
     ::variants::V v;
-    stdb::container::stdb_vector<::variants::V> vv;
+    FastVec<::variants::V> vv;
     std::unordered_map<stdb::memory::string, ::variants::V> vm;
     std::optional<::variants::V> vo;
 
     size_t fbe_type() const noexcept { return 1; }
 
     Line();
-    Line(::variants::V&& arg_v, stdb::container::stdb_vector<::variants::V> arg_vv, std::unordered_map<stdb::memory::string, ::variants::V> arg_vm, std::optional<::variants::V> arg_vo);
+    Line(::variants::V&& arg_v, FastVec<::variants::V> arg_vv, std::unordered_map<stdb::memory::string, ::variants::V> arg_vm, std::optional<::variants::V> arg_vo);
     Line(const Line& other) = default;
     Line(Line&& other) noexcept;
     ~Line() override;

--- a/proto/test.cpp
+++ b/proto/test.cpp
@@ -1108,7 +1108,7 @@ StructVector::StructVector()
     , f10()
 {}
 
-StructVector::StructVector(const stdb::container::stdb_vector<uint8_t>& arg_f1, const stdb::container::stdb_vector<std::optional<uint8_t>>& arg_f2, const stdb::container::stdb_vector<FBE::buffer_t>& arg_f3, const stdb::container::stdb_vector<std::optional<FBE::buffer_t>>& arg_f4, const stdb::container::stdb_vector<::test::EnumSimple>& arg_f5, const stdb::container::stdb_vector<std::optional<::test::EnumSimple>>& arg_f6, const stdb::container::stdb_vector<::test::FlagsSimple>& arg_f7, const stdb::container::stdb_vector<std::optional<::test::FlagsSimple>>& arg_f8, const stdb::container::stdb_vector<::test::StructSimple>& arg_f9, const stdb::container::stdb_vector<std::optional<::test::StructSimple>>& arg_f10)
+StructVector::StructVector(const FastVec<uint8_t>& arg_f1, const FastVec<std::optional<uint8_t>>& arg_f2, const FastVec<FBE::buffer_t>& arg_f3, const FastVec<std::optional<FBE::buffer_t>>& arg_f4, const FastVec<::test::EnumSimple>& arg_f5, const FastVec<std::optional<::test::EnumSimple>>& arg_f6, const FastVec<::test::FlagsSimple>& arg_f7, const FastVec<std::optional<::test::FlagsSimple>>& arg_f8, const FastVec<::test::StructSimple>& arg_f9, const FastVec<std::optional<::test::StructSimple>>& arg_f10)
     : f1(arg_f1)
     , f2(arg_f2)
     , f3(arg_f3)

--- a/proto/test.h
+++ b/proto/test.h
@@ -543,21 +543,21 @@ namespace test {
 
 struct StructVector
 {
-    stdb::container::stdb_vector<uint8_t> f1;
-    stdb::container::stdb_vector<std::optional<uint8_t>> f2;
-    stdb::container::stdb_vector<FBE::buffer_t> f3;
-    stdb::container::stdb_vector<std::optional<FBE::buffer_t>> f4;
-    stdb::container::stdb_vector<::test::EnumSimple> f5;
-    stdb::container::stdb_vector<std::optional<::test::EnumSimple>> f6;
-    stdb::container::stdb_vector<::test::FlagsSimple> f7;
-    stdb::container::stdb_vector<std::optional<::test::FlagsSimple>> f8;
-    stdb::container::stdb_vector<::test::StructSimple> f9;
-    stdb::container::stdb_vector<std::optional<::test::StructSimple>> f10;
+    FastVec<uint8_t> f1;
+    FastVec<std::optional<uint8_t>> f2;
+    FastVec<FBE::buffer_t> f3;
+    FastVec<std::optional<FBE::buffer_t>> f4;
+    FastVec<::test::EnumSimple> f5;
+    FastVec<std::optional<::test::EnumSimple>> f6;
+    FastVec<::test::FlagsSimple> f7;
+    FastVec<std::optional<::test::FlagsSimple>> f8;
+    FastVec<::test::StructSimple> f9;
+    FastVec<std::optional<::test::StructSimple>> f10;
 
     size_t fbe_type() const noexcept { return 130; }
 
     StructVector();
-    StructVector(const stdb::container::stdb_vector<uint8_t>& arg_f1, const stdb::container::stdb_vector<std::optional<uint8_t>>& arg_f2, const stdb::container::stdb_vector<FBE::buffer_t>& arg_f3, const stdb::container::stdb_vector<std::optional<FBE::buffer_t>>& arg_f4, const stdb::container::stdb_vector<::test::EnumSimple>& arg_f5, const stdb::container::stdb_vector<std::optional<::test::EnumSimple>>& arg_f6, const stdb::container::stdb_vector<::test::FlagsSimple>& arg_f7, const stdb::container::stdb_vector<std::optional<::test::FlagsSimple>>& arg_f8, const stdb::container::stdb_vector<::test::StructSimple>& arg_f9, const stdb::container::stdb_vector<std::optional<::test::StructSimple>>& arg_f10);
+    StructVector(const FastVec<uint8_t>& arg_f1, const FastVec<std::optional<uint8_t>>& arg_f2, const FastVec<FBE::buffer_t>& arg_f3, const FastVec<std::optional<FBE::buffer_t>>& arg_f4, const FastVec<::test::EnumSimple>& arg_f5, const FastVec<std::optional<::test::EnumSimple>>& arg_f6, const FastVec<::test::FlagsSimple>& arg_f7, const FastVec<std::optional<::test::FlagsSimple>>& arg_f8, const FastVec<::test::StructSimple>& arg_f9, const FastVec<std::optional<::test::StructSimple>>& arg_f10);
     StructVector(const StructVector& other) = default;
     StructVector(StructVector&& other) = default;
     ~StructVector() = default;

--- a/proto/variants.h
+++ b/proto/variants.h
@@ -37,7 +37,7 @@ struct Value;
 using Expr = std::variant<bool, int32_t, stdb::memory::string>;
 std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const Expr& value);
 
-using V = std::variant<stdb::memory::string, int32_t, double, ::variants::Simple, stdb::container::stdb_vector<::variants::Simple>, stdb::container::stdb_vector<int32_t>, std::unordered_map<int32_t, ::variants::Simple>, stdb::container::stdb_vector<FBE::buffer_t>, stdb::container::stdb_vector<stdb::memory::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<stdb::memory::string, FBE::buffer_t>, ::variants::Expr>;
+using V = std::variant<stdb::memory::string, int32_t, double, ::variants::Simple, FastVec<::variants::Simple>, FastVec<int32_t>, std::unordered_map<int32_t, ::variants::Simple>, FastVec<FBE::buffer_t>, FastVec<stdb::memory::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<stdb::memory::string, FBE::buffer_t>, ::variants::Expr>;
 std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const V& value);
 
 struct Simple

--- a/proto/variants_models.cpp
+++ b/proto/variants_models.cpp
@@ -347,14 +347,14 @@ void FieldModel<::variants::V>::get(::variants::V& fbe_value) const noexcept
         }
         case 4: {
             FieldModelVector<::variants::Simple> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<::variants::Simple>>();
+            fbe_value.emplace<FastVec<::variants::Simple>>();
             auto& value = std::get<4>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 5: {
             FieldModelVector<int32_t> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<int32_t>>();
+            fbe_value.emplace<FastVec<int32_t>>();
             auto& value = std::get<5>(fbe_value);
             fbe_model.get(value);
             break;
@@ -368,14 +368,14 @@ void FieldModel<::variants::V>::get(::variants::V& fbe_value) const noexcept
         }
         case 7: {
             FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<FBE::buffer_t>>();
+            fbe_value.emplace<FastVec<FBE::buffer_t>>();
             auto& value = std::get<7>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 8: {
             FieldModelVector<stdb::memory::string> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<stdb::memory::string>>();
+            fbe_value.emplace<FastVec<stdb::memory::string>>();
             auto& value = std::get<8>(fbe_value);
             fbe_model.get(value);
             break;
@@ -472,7 +472,7 @@ void FieldModel<::variants::V>::set(const ::variants::V& fbe_value) noexcept
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<::variants::Simple>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<::variants::Simple>& v) {
                 FieldModelVector<::variants::Simple> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -480,7 +480,7 @@ void FieldModel<::variants::V>::set(const ::variants::V& fbe_value) noexcept
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<int32_t>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<int32_t>& v) {
                 FieldModelVector<int32_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -496,7 +496,7 @@ void FieldModel<::variants::V>::set(const ::variants::V& fbe_value) noexcept
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<FBE::buffer_t>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<FBE::buffer_t>& v) {
                 FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -504,7 +504,7 @@ void FieldModel<::variants::V>::set(const ::variants::V& fbe_value) noexcept
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<stdb::memory::string>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<stdb::memory::string>& v) {
                 FieldModelVector<stdb::memory::string> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)

--- a/proto/variants_ptr_ptr.cpp
+++ b/proto/variants_ptr_ptr.cpp
@@ -465,7 +465,7 @@ ValueContainer::ValueContainer()
     , vm()
 {}
 
-ValueContainer::ValueContainer(stdb::container::stdb_vector<::variants_ptr::V> arg_vv, std::unordered_map<int32_t, ::variants_ptr::V> arg_vm)
+ValueContainer::ValueContainer(FastVec<::variants_ptr::V> arg_vv, std::unordered_map<int32_t, ::variants_ptr::V> arg_vm)
     : vv(std::move(arg_vv))
     , vm(std::move(arg_vm))
 {}

--- a/proto/variants_ptr_ptr.h
+++ b/proto/variants_ptr_ptr.h
@@ -41,7 +41,7 @@ using Expr = std::variant<bool, stdb::memory::string, int32_t>;
 std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const Expr& value);
 auto is_equal(const Expr& lhs, const Expr& rhs) -> bool;
 
-using V = std::variant<int32_t, stdb::memory::string, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, stdb::container::stdb_vector<::variants_ptr::Simple>, stdb::container::stdb_vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>, stdb::container::stdb_vector<FBE::buffer_t>, stdb::container::stdb_vector<stdb::memory::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<stdb::memory::string, FBE::buffer_t>, stdb::container::stdb_vector<::variants_ptr::Simple*>, ::variants_ptr::Expr>;
+using V = std::variant<int32_t, stdb::memory::string, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, FastVec<::variants_ptr::Simple>, FastVec<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>, FastVec<FBE::buffer_t>, FastVec<stdb::memory::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<stdb::memory::string, FBE::buffer_t>, FastVec<::variants_ptr::Simple*>, ::variants_ptr::Expr>;
 std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const V& value);
 auto is_equal(const V& lhs, const V& rhs) -> bool;
 
@@ -143,13 +143,13 @@ namespace variants_ptr {
 
 struct ValueContainer : FBE::Base
 {
-    stdb::container::stdb_vector<::variants_ptr::V> vv;
+    FastVec<::variants_ptr::V> vv;
     std::unordered_map<int32_t, ::variants_ptr::V> vm;
 
     size_t fbe_type() const noexcept { return 3; }
 
     ValueContainer();
-    ValueContainer(stdb::container::stdb_vector<::variants_ptr::V> arg_vv, std::unordered_map<int32_t, ::variants_ptr::V> arg_vm);
+    ValueContainer(FastVec<::variants_ptr::V> arg_vv, std::unordered_map<int32_t, ::variants_ptr::V> arg_vm);
     ValueContainer(const ValueContainer& other) = default;
     ValueContainer(ValueContainer&& other) noexcept;
     ~ValueContainer() override;

--- a/proto/variants_ptr_ptr_models.cpp
+++ b/proto/variants_ptr_ptr_models.cpp
@@ -366,14 +366,14 @@ void FieldModel<::variants_ptr::V>::get(::variants_ptr::V& fbe_value) const noex
         }
         case 5: {
             FieldModelCustomVector<FieldModel_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<::variants_ptr::Simple>>();
+            fbe_value.emplace<FastVec<::variants_ptr::Simple>>();
             auto& value = std::get<5>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 6: {
             FieldModelVector<int32_t> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<int32_t>>();
+            fbe_value.emplace<FastVec<int32_t>>();
             auto& value = std::get<6>(fbe_value);
             fbe_model.get(value);
             break;
@@ -387,14 +387,14 @@ void FieldModel<::variants_ptr::V>::get(::variants_ptr::V& fbe_value) const noex
         }
         case 8: {
             FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<FBE::buffer_t>>();
+            fbe_value.emplace<FastVec<FBE::buffer_t>>();
             auto& value = std::get<8>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 9: {
             FieldModelVector<stdb::memory::string> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<stdb::memory::string>>();
+            fbe_value.emplace<FastVec<stdb::memory::string>>();
             auto& value = std::get<9>(fbe_value);
             fbe_model.get(value);
             break;
@@ -415,7 +415,7 @@ void FieldModel<::variants_ptr::V>::get(::variants_ptr::V& fbe_value) const noex
         }
         case 12: {
             FieldModelCustomVector<FieldModelPtr_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
-            fbe_value.emplace<stdb::container::stdb_vector<::variants_ptr::Simple*>>();
+            fbe_value.emplace<FastVec<::variants_ptr::Simple*>>();
             auto& value = std::get<12>(fbe_value);
             fbe_model.get(value);
             break;
@@ -506,7 +506,7 @@ void FieldModel<::variants_ptr::V>::set(const ::variants_ptr::V& fbe_value) noex
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<::variants_ptr::Simple>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<::variants_ptr::Simple>& v) {
                 FieldModelCustomVector<FieldModel_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -514,7 +514,7 @@ void FieldModel<::variants_ptr::V>::set(const ::variants_ptr::V& fbe_value) noex
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<int32_t>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<int32_t>& v) {
                 FieldModelVector<int32_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -530,7 +530,7 @@ void FieldModel<::variants_ptr::V>::set(const ::variants_ptr::V& fbe_value) noex
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<FBE::buffer_t>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<FBE::buffer_t>& v) {
                 FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -538,7 +538,7 @@ void FieldModel<::variants_ptr::V>::set(const ::variants_ptr::V& fbe_value) noex
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<stdb::memory::string>& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<stdb::memory::string>& v) {
                 FieldModelVector<stdb::memory::string> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
@@ -562,7 +562,7 @@ void FieldModel<::variants_ptr::V>::set(const ::variants_ptr::V& fbe_value) noex
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, fbe_variant_index = fbe_value.index()](const stdb::container::stdb_vector<::variants_ptr::Simple*> v) {
+            , [this, fbe_variant_index = fbe_value.index()](const FastVec<::variants_ptr::Simple*> v) {
                 FieldModelCustomVector<FieldModelPtr_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -467,10 +467,10 @@ void GeneratorCpp::GenerateBufferWrapper_Header()
 class buffer_t
 {
 public:
-    typedef FastVec<uint8_t>::Iterator iterator;
-    typedef FastVec<uint8_t>::ConstIterator const_iterator;
-    typedef FastVec<uint8_t>::ReverseIterator reverse_iterator;
-    typedef FastVec<uint8_t>::ConstReverseIterator const_reverse_iterator;
+    typedef FastVec<uint8_t>::iterator iterator;
+    typedef FastVec<uint8_t>::const_iterator const_iterator;
+    typedef FastVec<uint8_t>::reverse_iterator reverse_iterator;
+    typedef FastVec<uint8_t>::const_reverse_iterator const_reverse_iterator;
 
     buffer_t() = default;
     buffer_t(size_t capacity) { reserve(capacity); }

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -226,6 +226,12 @@ namespace pmr = std::pmr;
 #include "container/stdb_vector.hpp"
 
 namespace FBE {
+    template <typename T>
+    #if defined(USING_STD_VECTOR)
+    using FastVec = std::vector<T>;
+    #else
+    using FastVec = stdb::container::stdb_vector<T>;
+    #endif
     using Safety = stdb::container::Safety;
 }
 
@@ -455,31 +461,31 @@ void GeneratorCpp::GenerateBufferWrapper_Header()
     std::string code = R"CODE(
 //! Bytes buffer type
 /*!
-    Represents bytes buffer which is a lightweight wrapper around stdb::container::stdb_vector<uint8_t>
+    Represents bytes buffer which is a lightweight wrapper around FastVec<uint8_t>
     with similar interface.
 */
 class buffer_t
 {
 public:
-    typedef stdb::container::stdb_vector<uint8_t>::Iterator iterator;
-    typedef stdb::container::stdb_vector<uint8_t>::ConstIterator const_iterator;
-    typedef stdb::container::stdb_vector<uint8_t>::ReverseIterator reverse_iterator;
-    typedef stdb::container::stdb_vector<uint8_t>::ConstReverseIterator const_reverse_iterator;
+    typedef FastVec<uint8_t>::Iterator iterator;
+    typedef FastVec<uint8_t>::ConstIterator const_iterator;
+    typedef FastVec<uint8_t>::ReverseIterator reverse_iterator;
+    typedef FastVec<uint8_t>::ConstReverseIterator const_reverse_iterator;
 
     buffer_t() = default;
     buffer_t(size_t capacity) { reserve(capacity); }
     buffer_t(const std::string& str) { assign(str); }
     buffer_t(size_t size, uint8_t value) { assign(size, value); }
     buffer_t(const uint8_t* data, size_t size) { assign(data, size); }
-    buffer_t(const stdb::container::stdb_vector<uint8_t>& other) : _data(other) {}
-    buffer_t(stdb::container::stdb_vector<uint8_t>&& other) : _data(std::move(other)) {}
+    buffer_t(const FastVec<uint8_t>& other) : _data(other) {}
+    buffer_t(FastVec<uint8_t>&& other) : _data(std::move(other)) {}
     buffer_t(const buffer_t& other) = default;
     buffer_t(buffer_t&& other) = default;
     ~buffer_t() = default;
 
     buffer_t& operator=(const std::string& str) { assign(str); return *this; }
-    buffer_t& operator=(const stdb::container::stdb_vector<uint8_t>& other) { _data = other; return *this; }
-    buffer_t& operator=(stdb::container::stdb_vector<uint8_t>&& other) { _data = std::move(other); return *this; }
+    buffer_t& operator=(const FastVec<uint8_t>& other) { _data = other; return *this; }
+    buffer_t& operator=(FastVec<uint8_t>&& other) { _data = std::move(other); return *this; }
     buffer_t& operator=(const buffer_t& other) = default;
     buffer_t& operator=(buffer_t&& other) = default;
 
@@ -494,8 +500,8 @@ public:
     size_t size() const { return _data.size(); }
     size_t max_size() const { return _data.max_size(); }
 
-    stdb::container::stdb_vector<uint8_t>& buffer() noexcept { return _data; }
-    const stdb::container::stdb_vector<uint8_t>& buffer() const noexcept { return _data; }
+    FastVec<uint8_t>& buffer() noexcept { return _data; }
+    const FastVec<uint8_t>& buffer() const noexcept { return _data; }
     uint8_t* data() noexcept { return _data.data(); }
     const uint8_t* data() const noexcept { return _data.data(); }
     uint8_t& at(size_t index) { return _data.at(index); }
@@ -510,14 +516,14 @@ public:
     void shrink_to_fit() { _data.shrink_to_fit(); }
 
     void assign(const std::string& str) { assign((const uint8_t*)str.c_str(), str.size()); }
-    void assign(const stdb::container::stdb_vector<uint8_t>& vec) { assign(vec.begin(), vec.end()); }
+    void assign(const FastVec<uint8_t>& vec) { assign(vec.begin(), vec.end()); }
     void assign(size_t size, uint8_t value) { _data.assign(size, value); }
     void assign(const uint8_t* data, size_t size) { _data.assign(data, data + size); }
     template <class InputIterator>
     void assign(InputIterator first, InputIterator last) { _data.assign(first, last); }
     iterator insert(const_iterator position, uint8_t value) { return _data.insert(position, value); }
     iterator insert(const_iterator position, const std::string& str) { return insert(position, (const uint8_t*)str.c_str(), str.size()); }
-    iterator insert(const_iterator position, const stdb::container::stdb_vector<uint8_t>& vec) { return insert(position, vec.begin(), vec.end()); }
+    iterator insert(const_iterator position, const FastVec<uint8_t>& vec) { return insert(position, vec.begin(), vec.end()); }
     iterator insert(const_iterator position, size_t size, uint8_t value) { return _data.insert(position, size, value); }
     iterator insert(const_iterator position, const uint8_t* data, size_t size) { return _data.insert(position, data, data + size); }
     template <class InputIterator>
@@ -562,7 +568,7 @@ public:
     { value1.swap(value2); }
 
 private:
-    stdb::container::stdb_vector<uint8_t> _data;
+    FastVec<uint8_t> _data;
 };
 )CODE";
 
@@ -1514,7 +1520,7 @@ public:
     // Initialize the read buffer with the given byte buffer and offset
     explicit FBEBuffer(const void* data, size_t size, size_t offset = 0) { attach(data, size, offset); }
     // Initialize the read buffer with the given byte vector and offset
-    explicit FBEBuffer(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset = 0) { attach(buffer, offset); }
+    explicit FBEBuffer(const FastVec<uint8_t>& buffer, size_t offset = 0) { attach(buffer, offset); }
     // Initialize the read buffer with another buffer and offset
     explicit FBEBuffer(const FBEBuffer& buffer, size_t offset = 0) { attach(buffer.data(), buffer.size(), offset); }
     // Initialize the write buffer with the given capacity
@@ -1536,12 +1542,12 @@ public:
     // Attach the given buffer with a given offset to the current read buffer
     void attach(const void* data, size_t size, size_t offset = 0);
     // Attach the given byte vector with a given offset to the current read buffer
-    void attach(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset = 0);
+    void attach(const FastVec<uint8_t>& buffer, size_t offset = 0);
 
     // Clone the given buffer with a given offset to the current buffer
     void clone(const void* data, size_t size, size_t offset = 0);
     // Clone the given vector with a given offset to the current buffer
-    void clone(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset = 0);
+    void clone(const FastVec<uint8_t>& buffer, size_t offset = 0);
 
     // Allocate memory in the current write buffer and return offset to the allocated memory block
     size_t allocate(size_t size);
@@ -1594,7 +1600,7 @@ void FBEBuffer::attach(const void* data, size_t size, size_t offset)
     _offset = offset;
 }
 
-void FBEBuffer::attach(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset)
+void FBEBuffer::attach(const FastVec<uint8_t>& buffer, size_t offset)
 {
     assert((buffer.data() != nullptr) && "Invalid buffer!");
     if (buffer.data() == nullptr)
@@ -1625,7 +1631,7 @@ void FBEBuffer::clone(const void* data, size_t size, size_t offset)
     _offset = offset;
 }
 
-void FBEBuffer::clone(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset)
+void FBEBuffer::clone(const FastVec<uint8_t>& buffer, size_t offset)
 {
     assert((offset <= buffer.size()) && "Invalid offset!");
     if (offset > buffer.size())
@@ -1738,7 +1744,7 @@ public:
 
     // Attach the model buffer
     void attach(const void* data, size_t size, size_t offset = 0) { _buffer->attach(data, size, offset); }
-    void attach(const stdb::container::stdb_vector<uint8_t>& buffer, size_t offset = 0) { _buffer->attach(buffer, offset); }
+    void attach(const FastVec<uint8_t>& buffer, size_t offset = 0) { _buffer->attach(buffer, offset); }
     void attach(const FBEBuffer& buffer, size_t offset = 0) { _buffer->attach(buffer.data(), buffer.size(), offset); }
 
     // Model buffer operations
@@ -2263,7 +2269,7 @@ public:
     template <size_t N>
     size_t get(std::array<uint8_t, N>& data) const noexcept { return get(data.data(), data.size()); }
     // Get the bytes value
-    void get(stdb::container::stdb_vector<uint8_t>& value) const noexcept;
+    void get(FastVec<uint8_t>& value) const noexcept;
     // Get the bytes value
     void get(buffer_t& value) const noexcept { get(value.buffer()); }
 
@@ -2276,7 +2282,7 @@ public:
     template <size_t N>
     void set(const std::array<uint8_t, N>& data) { set(data.data(), data.size()); }
     // Set the bytes value
-    void set(const stdb::container::stdb_vector<uint8_t>& value) { set(value.data(), value.size()); }
+    void set(const FastVec<uint8_t>& value) { set(value.data(), value.size()); }
     // Set the bytes value
     void set(const buffer_t& value) { set(value.buffer()); }
 
@@ -2354,7 +2360,7 @@ size_t FieldModel<buffer_t>::get(void* data, size_t size) const noexcept
     return result;
 }
 
-void FieldModel<buffer_t>::get(stdb::container::stdb_vector<uint8_t>& value) const noexcept
+void FieldModel<buffer_t>::get(FastVec<uint8_t>& value) const noexcept
 {
     value.clear();
 
@@ -3705,8 +3711,8 @@ public:
     // Get the array as std::array
     template <size_t S>
     void get(std::array<T, S>& values) const noexcept;
-    // Get the array as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the array as FastVec
+    void get(FastVec<T>& values) const noexcept;
 
     // Set the array as C-array
     template <size_t S>
@@ -3714,8 +3720,8 @@ public:
     // Set the array as std::array
     template <size_t S>
     void set(const std::array<T, S>& values) noexcept;
-    // Set the array as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the array as FastVec
+    void set(const FastVec<T>& values) noexcept;
 
 private:
     FBEBuffer& _buffer;
@@ -3800,7 +3806,7 @@ inline void FieldModelArray<T, N>::get(std::array<T, S>& values) const noexcept
 }
 
 template <typename T, size_t N>
-inline void FieldModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline void FieldModelArray<T, N>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -3810,7 +3816,11 @@ inline void FieldModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) 
     {
         T value = T();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -3848,7 +3858,7 @@ inline void FieldModelArray<T, N>::set(const std::array<T, S>& values) noexcept
 }
 
 template <typename T, size_t N>
-inline void FieldModelArray<T, N>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline void FieldModelArray<T, N>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -3905,8 +3915,8 @@ public:
     // Check if the vector is valid
     bool verify() const noexcept;
 
-    // Get the vector as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the vector as FastVec
+    void get(FastVec<T>& values) const noexcept;
     // Get the vector as std::list
     void get(std::list<T>& values) const noexcept;
     // Get the vector as std::set
@@ -3919,8 +3929,8 @@ public:
     // Get the vector as pmr::set
     void get(pmr::set<T>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the vector as FastVec
+    void set(const FastVec<T>& values) noexcept;
     // Set the vector as std::list
     void set(const std::list<T>& values) noexcept;
     // Set the vector as std::set
@@ -4054,7 +4064,7 @@ inline bool FieldModelVector<T>::verify() const noexcept
 }
 
 template <typename T>
-inline void FieldModelVector<T>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline void FieldModelVector<T>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -4069,7 +4079,11 @@ inline void FieldModelVector<T>::get(stdb::container::stdb_vector<T>& values) co
     {
         T value = T();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -4172,7 +4186,7 @@ inline void FieldModelVector<T>::get(pmr::set<T>& values) const noexcept
 }
 
 template <typename T>
-inline void FieldModelVector<T>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline void FieldModelVector<T>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -5134,7 +5148,7 @@ public:
     size_t fbe_allocation_size(const uint8_t (&data)[N]) const noexcept { return 4 + N; }
     template <size_t N>
     size_t fbe_allocation_size(const std::array<uint8_t, N>& data) const noexcept { return 4 + N; }
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<uint8_t>& value) const noexcept { return 4 + value.size(); }
+    size_t fbe_allocation_size(const FastVec<uint8_t>& value) const noexcept { return 4 + value.size(); }
     size_t fbe_allocation_size(const buffer_t& value) const noexcept { return 4 + value.size(); }
 
     // Get the field offset
@@ -5159,7 +5173,7 @@ public:
     template <size_t N>
     size_t get(std::array<uint8_t, N>& data) const noexcept { return get(data.data(), data.size()); }
     // Get the bytes value
-    size_t get(stdb::container::stdb_vector<uint8_t>& value) const noexcept;
+    size_t get(FastVec<uint8_t>& value) const noexcept;
     // Get the bytes value
     size_t get(buffer_t& value) const noexcept { return get(value.buffer()); }
 
@@ -5172,7 +5186,7 @@ public:
     template <size_t N>
     size_t set(const std::array<uint8_t, N>& data) { return set(data.data(), data.size()); }
     // Set the bytes value
-    size_t set(const stdb::container::stdb_vector<uint8_t>& value) { return set(value.data(), value.size()); }
+    size_t set(const FastVec<uint8_t>& value) { return set(value.data(), value.size()); }
     // Set the bytes value
     size_t set(const buffer_t& value) { return set(value.buffer()); }
 
@@ -5223,7 +5237,7 @@ size_t FinalModel<buffer_t>::get(void* data, size_t size) const noexcept
     return 4 + fbe_bytes_size;
 }
 
-size_t FinalModel<buffer_t>::get(stdb::container::stdb_vector<uint8_t>& value) const noexcept
+size_t FinalModel<buffer_t>::get(FastVec<uint8_t>& value) const noexcept
 {
     value.clear();
 
@@ -5575,7 +5589,7 @@ public:
     size_t fbe_allocation_size(const T (&values)[S]) const noexcept;
     template <size_t S>
     size_t fbe_allocation_size(const std::array<T, S>& values) const noexcept;
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept;
+    size_t fbe_allocation_size(const FastVec<T>& values) const noexcept;
 
     // Get the field offset
     size_t fbe_offset() const noexcept { return _offset; }
@@ -5596,8 +5610,8 @@ public:
     // Get the array as std::array
     template <size_t S>
     size_t get(std::array<T, S>& values) const noexcept;
-    // Get the array as stdb::container::stdb_vector
-    size_t get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the array as FastVec
+    size_t get(FastVec<T>& values) const noexcept;
 
     // Set the array as C-array
     template <size_t S>
@@ -5605,8 +5619,8 @@ public:
     // Set the array as std::array
     template <size_t S>
     size_t set(const std::array<T, S>& values) noexcept;
-    // Set the array as stdb::container::stdb_vector
-    size_t set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the array as FastVec
+    size_t set(const FastVec<T>& values) noexcept;
 
 private:
     FBEBuffer& _buffer;
@@ -5646,7 +5660,7 @@ inline size_t FinalModelArray<T, N>::fbe_allocation_size(const std::array<T, S>&
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelArray<T, N>::fbe_allocation_size(const FastVec<T>& values) const noexcept
 {
     size_t size = 0;
     FinalModel<T> fbe_model(_buffer, fbe_offset());
@@ -5713,7 +5727,7 @@ inline size_t FinalModelArray<T, N>::get(std::array<T, S>& values) const noexcep
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelArray<T, N>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -5729,7 +5743,11 @@ inline size_t FinalModelArray<T, N>::get(stdb::container::stdb_vector<T>& values
     {
         T value = T();
         size_t offset = fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(offset);
         size += offset;
     }
@@ -5775,7 +5793,7 @@ inline size_t FinalModelArray<T, N>::set(const std::array<T, S>& values) noexcep
 }
 
 template <typename T, size_t N>
-inline size_t FinalModelArray<T, N>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline size_t FinalModelArray<T, N>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset()) > _buffer.size())
@@ -5810,7 +5828,7 @@ public:
     FinalModelVector(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
 
     // Get the allocation size
-    size_t fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept;
+    size_t fbe_allocation_size(const FastVec<T>& values) const noexcept;
     size_t fbe_allocation_size(const std::list<T>& values) const noexcept;
     size_t fbe_allocation_size(const std::set<T>& values) const noexcept;
 
@@ -5827,15 +5845,15 @@ public:
     // Check if the vector is valid
     size_t verify() const noexcept;
 
-    // Get the vector as stdb::container::stdb_vector
-    size_t get(stdb::container::stdb_vector<T>& values) const noexcept;
+    // Get the vector as FastVec
+    size_t get(FastVec<T>& values) const noexcept;
     // Get the vector as std::list
     size_t get(std::list<T>& values) const noexcept;
     // Get the vector as std::set
     size_t get(std::set<T>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    size_t set(const stdb::container::stdb_vector<T>& values) noexcept;
+    // Set the vector as FastVec
+    size_t set(const FastVec<T>& values) noexcept;
     // Set the vector as std::list
     size_t set(const std::list<T>& values) noexcept;
     // Set the vector as std::set
@@ -5857,7 +5875,7 @@ void GeneratorCpp::GenerateFBEFinalModelVector_Inline()
 {
     std::string code = R"CODE(
 template <typename T>
-inline size_t FinalModelVector<T>::fbe_allocation_size(const stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelVector<T>::fbe_allocation_size(const FastVec<T>& values) const noexcept
 {
     size_t size = 4;
     FinalModel<T> fbe_model(_buffer, fbe_offset() + 4);
@@ -5908,7 +5926,7 @@ inline size_t FinalModelVector<T>::verify() const noexcept
 }
 
 template <typename T>
-inline size_t FinalModelVector<T>::get(stdb::container::stdb_vector<T>& values) const noexcept
+inline size_t FinalModelVector<T>::get(FastVec<T>& values) const noexcept
 {
     values.clear();
 
@@ -5928,7 +5946,11 @@ inline size_t FinalModelVector<T>::get(stdb::container::stdb_vector<T>& values) 
     {
         T value = T();
         size_t offset = fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(offset);
         size += offset;
     }
@@ -5988,7 +6010,7 @@ inline size_t FinalModelVector<T>::get(std::set<T>& values) const noexcept
 }
 
 template <typename T>
-inline size_t FinalModelVector<T>::set(const stdb::container::stdb_vector<T>& values) noexcept
+inline size_t FinalModelVector<T>::set(const FastVec<T>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + 4) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + 4) > _buffer.size())
@@ -6988,9 +7010,9 @@ struct ValueWriter<TWriter, std::array<T, N>>
 };
 
 template <class TWriter, typename T>
-struct ValueWriter<TWriter, stdb::container::stdb_vector<T>>
+struct ValueWriter<TWriter, FastVec<T>>
 {
-    static bool to_json(TWriter& writer, const stdb::container::stdb_vector<T>& values, bool scope = true)
+    static bool to_json(TWriter& writer, const FastVec<T>& values, bool scope = true)
     {
         writer.StartArray();
         for (const auto& value : values)
@@ -7558,9 +7580,9 @@ struct ValueReader<TJson, std::array<T, N>>
 };
 
 template <class TJson, typename T>
-struct ValueReader<TJson, stdb::container::stdb_vector<T>>
+struct ValueReader<TJson, FastVec<T>>
 {
-    static bool from_json(const TJson& json, stdb::container::stdb_vector<T>& values)
+    static bool from_json(const TJson& json, FastVec<T>& values)
     {
         values.clear();
 
@@ -7575,7 +7597,11 @@ struct ValueReader<TJson, stdb::container::stdb_vector<T>>
             T temp = T();
             if (!FBE::JSON::from_json(item, temp))
                 return false;
+            #if defined(USING_STD_VECTOR)
+            values.emplace_back(temp);
+            #else
             values.template emplace_back<Safety::Unsafe>(temp);
+            #endif
         }
         return true;
     }
@@ -12094,7 +12120,7 @@ std::string GeneratorCpp::ConvertTypeName(const std::string& package, const Stru
     if (field.array)
         return "std::array<" + ConvertTypeName(package, *field.type, field.optional) + ", " + std::to_string(field.N) + ">";
     else if (field.vector) 
-        return (Arena() ? "pmr::vector<" : "stdb::container::stdb_vector<") + ConvertTypeName(package, *field.type, field.optional) + ">";
+        return (Arena() ? "pmr::vector<" : "FastVec<") + ConvertTypeName(package, *field.type, field.optional) + ">";
     else if (field.list)
         return prefix + "::list<" + ConvertTypeName(package, *field.type, field.optional) + ">";
     else if (field.set)

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -361,18 +361,18 @@ public:
 )CODE";
 
     std::string code_extra = R"CODE(
-    // Get the array as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<TStruct>& values) const noexcept;
-    void get(stdb::container::stdb_vector<TStruct*>& values) const noexcept;
+    // Get the array as FastVec
+    void get(FastVec<TStruct>& values) const noexcept;
+    void get(FastVec<TStruct*>& values) const noexcept;
 
-    // Set the array as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<TStruct>& values) noexcept;
-    void set(const stdb::container::stdb_vector<TStruct*>& values) noexcept;
+    // Set the array as FastVec
+    void set(const FastVec<TStruct>& values) noexcept;
+    void set(const FastVec<TStruct*>& values) noexcept;
 )CODE";
 
     code += code_extra;
 
-    code_extra = std::regex_replace(code_extra, std::regex("stdb::container::stdb_vector"), "pmr::vector");
+    code_extra = std::regex_replace(code_extra, std::regex("FastVec"), "pmr::vector");
     code_extra = std::regex_replace(code_extra, std::regex("std::list"), "pmr::list");
     code += code_extra;
 
@@ -555,7 +555,7 @@ inline void FieldModelCustomArray<T, TStruct, N>::set(const std::array<TStruct*,
 
 std::string code_extra = R"CODE(
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vector<TStruct>& values) const noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::get(FastVec<TStruct>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -565,13 +565,17 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vect
     {
         TStruct value;
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vector<TStruct*>& values) const noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::get(FastVec<TStruct*>& values) const noexcept
 {
     values.clear();
     values.reserve(N);
@@ -581,13 +585,17 @@ inline void FieldModelCustomArray<T, TStruct, N>::get(stdb::container::stdb_vect
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::stdb_vector<TStruct>& values) noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::set(const FastVec<TStruct>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -602,7 +610,7 @@ inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::std
 }
 
 template <typename T, typename TStruct, size_t N>
-inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::stdb_vector<TStruct*>& values) noexcept
+inline void FieldModelCustomArray<T, TStruct, N>::set(const FastVec<TStruct*>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -618,7 +626,7 @@ inline void FieldModelCustomArray<T, TStruct, N>::set(const stdb::container::std
 )CODE";
     code += code_extra;
 
-    code_extra = std::regex_replace(code_extra, std::regex("stdb::container::stdb_vector"), "pmr::vector");
+    code_extra = std::regex_replace(code_extra, std::regex("FastVec"), "pmr::vector");
     code_extra = std::regex_replace(code_extra, std::regex("values.template emplace_back<Safety::Unsafe>"), "values.emplace_back");
     code_extra = std::regex_replace(code_extra, std::regex("std::list"), "pmr::list");
     code += code_extra;
@@ -666,9 +674,9 @@ public:
 )CODE";
 
     std::string code_extra = R"CODE(
-    // Get the vector as stdb::container::stdb_vector
-    void get(stdb::container::stdb_vector<TStruct>& values) const noexcept;
-    void get(stdb::container::stdb_vector<TStruct*>& values) const noexcept;
+    // Get the vector as FastVec
+    void get(FastVec<TStruct>& values) const noexcept;
+    void get(FastVec<TStruct*>& values) const noexcept;
     // Get the vector as std::list
     void get(std::list<TStruct>& values) const noexcept;
     void get(std::list<TStruct*>& values) const noexcept;
@@ -676,9 +684,9 @@ public:
     void get(std::set<TStruct>& values) const noexcept;
     void get(std::set<TStruct*>& values) const noexcept;
 
-    // Set the vector as stdb::container::stdb_vector
-    void set(const stdb::container::stdb_vector<TStruct>& values) noexcept;
-    void set(const stdb::container::stdb_vector<TStruct*>& values) noexcept;
+    // Set the vector as FastVec
+    void set(const FastVec<TStruct>& values) noexcept;
+    void set(const FastVec<TStruct*>& values) noexcept;
     // Set the vector as std::list
     void set(const std::list<TStruct>& values) noexcept;
     void set(const std::list<TStruct*>& values) noexcept;
@@ -688,7 +696,7 @@ public:
 )CODE";
 
     code += code_extra;
-    code_extra = std::regex_replace(code_extra, std::regex("stdb::container::stdb_vector"), "pmr::vector");
+    code_extra = std::regex_replace(code_extra, std::regex("FastVec"), "pmr::vector");
     code_extra = std::regex_replace(code_extra, std::regex("std::list"), "pmr::list");
     code_extra = std::regex_replace(code_extra, std::regex("std::set"), "pmr::set");
     code += code_extra;
@@ -817,7 +825,7 @@ inline bool FieldModelCustomVector<T, TStruct>::verify() const noexcept
 
 std::string code_extra = R"CODE(
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector<TStruct>& values) const noexcept
+inline void FieldModelCustomVector<T, TStruct>::get(FastVec<TStruct>& values) const noexcept
 {
     values.clear();
 
@@ -832,13 +840,17 @@ inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector
     {
         TStruct value = TStruct();
         fbe_model.get(value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(std::move(value));
+        #else
         values.template emplace_back<Safety::Unsafe>(std::move(value));
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector<TStruct*>& values) const noexcept
+inline void FieldModelCustomVector<T, TStruct>::get(FastVec<TStruct*>& values) const noexcept
 {
     values.clear();
 
@@ -853,7 +865,11 @@ inline void FieldModelCustomVector<T, TStruct>::get(stdb::container::stdb_vector
     {
         TStruct* value = nullptr;
         fbe_model.get(&value);
+        #if defined(USING_STD_VECTOR)
+        values.emplace_back(value);
+        #else
         values.template emplace_back<Safety::Unsafe>(value);
+        #endif
         fbe_model.fbe_shift(fbe_model.fbe_size());
     }
 }
@@ -935,7 +951,7 @@ inline void FieldModelCustomVector<T, TStruct>::get(std::set<TStruct*>& values) 
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_vector<TStruct>& values) noexcept
+inline void FieldModelCustomVector<T, TStruct>::set(const FastVec<TStruct>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -950,7 +966,7 @@ inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomVector<T, TStruct>::set(const stdb::container::stdb_vector<TStruct*>& values) noexcept
+inline void FieldModelCustomVector<T, TStruct>::set(const FastVec<TStruct*>& values) noexcept
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -1027,7 +1043,7 @@ inline void FieldModelCustomVector<T, TStruct>::set(const std::set<TStruct*>& va
 
     code += code_extra;
 
-    code_extra = std::regex_replace(code_extra, std::regex("stdb::container::stdb_vector"), "pmr::vector");
+    code_extra = std::regex_replace(code_extra, std::regex("FastVec"), "pmr::vector");
     code_extra = std::regex_replace(code_extra, std::regex("values.template emplace_back<Safety::Unsafe>"), "values.emplace_back");
     code_extra = std::regex_replace(code_extra, std::regex("std::list"), "pmr::list");
     code_extra = std::regex_replace(code_extra, std::regex("std::set"), "pmr::set");
@@ -2078,7 +2094,16 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                         WriteLineIndent(*field->name + ".reserve(arg_" + *field->name + ".size());");
                         WriteLineIndent("for (auto& it : arg_" + *field->name + ")");
                         Indent(1);
+                        // #if defined(USING_STD_VECTOR)
+                        // values.emplace_back(std::move(value));
+                        // #else
+                        // values.template emplace_back<Safety::Unsafe>(std::move(value));
+                        // #endif
+                        WriteLineIndent("#if defined(USING_STD_VECTOR)");
+                        WriteLineIndent(*field->name + ".emplace_back(it.release());");
+                        WriteLineIndent("#else");
                         WriteLineIndent(*field->name + ".emplace_back" + (Arena() ? "" : "<Safety::Unsafe>") + "(it.release());");
+                        WriteLineIndent("#endif");
                         Indent(-1);
                     } else if (field->list) {
                         WriteLineIndent("for (auto& it : arg_" + *field->name + ")");
@@ -3819,7 +3844,7 @@ GeneratorCpp::ConvertPtrTypeName(const std::string &package, const StructField &
     else if (field.optional)
         return "std::optional<" + ConvertPtrTypeName(package, *field.type) + ">";
     else if (field.vector)
-        return (Arena() ? "pmr::vector<" : "stdb::container::stdb_vector<") + ConvertPtrTypeName(package, *field.type, field.optional, typeptr, as_argument) + ">";
+        return (Arena() ? "pmr::vector<" : "FastVec<") + ConvertPtrTypeName(package, *field.type, field.optional, typeptr, as_argument) + ">";
     else if (field.list)
         return prefix + "::list<" + ConvertPtrTypeName(package, *field.type, field.optional, typeptr, as_argument) + ">";
     else if (field.set)
@@ -3841,7 +3866,7 @@ std::string GeneratorCpp::ConvertVariantTypeName(const std::string& package, con
         prefix = "pmr";
     }
     if (variant.vector)
-        return (Arena() ? "pmr::vector<" : "stdb::container::stdb_vector<") + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) + ">";
+        return (Arena() ? "pmr::vector<" : "FastVec<") + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) + ">";
     else if (variant.list)
         return prefix + "::list<" + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) + ">";
     else if (variant.map)

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -10,6 +10,13 @@
 #include "variants.h"
 #include <cstdint>
 
+template <typename T>
+#if defined(USING_STD_VECTOR)
+using FastVec = std::vector<T>;
+#else
+using FastVec = stdb::container::stdb_vector<T>;
+#endif
+
 TEST_CASE("Serialization: domain", "[FBE]")
 {
     // Create a new account with some orders
@@ -768,9 +775,9 @@ TEST_CASE("Serialization: struct array", "[FBE]")
     struct1.f1[1] = (uint8_t)65;
     struct1.f2[0] = (uint8_t)97;
     struct1.f2[1] = std::nullopt;
-    struct1.f3[0] = stdb::container::stdb_vector<uint8_t>(3, 48);
-    struct1.f3[1] = stdb::container::stdb_vector<uint8_t>(3, 65);
-    struct1.f4[0] = stdb::container::stdb_vector<uint8_t>(3, 97);
+    struct1.f3[0] = FastVec<uint8_t>(3, 48);
+    struct1.f3[1] = FastVec<uint8_t>(3, 65);
+    struct1.f4[0] = FastVec<uint8_t>(3, 97);
     struct1.f4[1] = std::nullopt;
     struct1.f5[0] = test::EnumSimple::ENUM_VALUE_1;
     struct1.f5[1] = test::EnumSimple::ENUM_VALUE_2;
@@ -868,9 +875,9 @@ TEST_CASE("Serialization: struct vector", "[FBE]")
     struct1.f1.emplace_back((uint8_t)65);
     struct1.f2.emplace_back((uint8_t)97);
     struct1.f2.emplace_back(std::nullopt);
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace_back(FastVec<uint8_t>(3, 97));
     struct1.f4.emplace_back(std::nullopt);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_2);
@@ -968,9 +975,9 @@ TEST_CASE("Serialization: struct list", "[FBE]")
     struct1.f1.emplace_back((uint8_t)65);
     struct1.f2.emplace_back((uint8_t)97);
     struct1.f2.emplace_back(std::nullopt);
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace_back(FastVec<uint8_t>(3, 97));
     struct1.f4.emplace_back(std::nullopt);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_2);
@@ -1127,9 +1134,9 @@ TEST_CASE("Serialization: struct map", "[FBE]")
     struct1.f1.emplace(20, (uint8_t)65);
     struct1.f2.emplace(10, (uint8_t)97);
     struct1.f2.emplace(20, std::nullopt);
-    struct1.f3.emplace(10, stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace(20, stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace(10, stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace(10, FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace(20, FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace(10, FastVec<uint8_t>(3, 97));
     struct1.f4.emplace(20, std::nullopt);
     struct1.f5.emplace(10, test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace(20, test::EnumSimple::ENUM_VALUE_2);
@@ -1214,9 +1221,9 @@ TEST_CASE("Serialization: struct hash", "[FBE]")
     struct1.f1.emplace("20", (uint8_t)65);
     struct1.f2.emplace("10", (uint8_t)97);
     struct1.f2.emplace("20", std::nullopt);
-    struct1.f3.emplace("10", stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace("20", stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace("10", stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace("10", FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace("20", FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace("10", FastVec<uint8_t>(3, 97));
     struct1.f4.emplace("20", std::nullopt);
     struct1.f5.emplace("10", test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace("20", test::EnumSimple::ENUM_VALUE_2);
@@ -1408,7 +1415,7 @@ TEST_CASE("Serialization: variant", "[FBE]") {
     }
 
     SECTION ("vector of struct") {
-        stdb::container::stdb_vector<::variants::Simple> v;
+        FastVec<::variants::Simple> v;
         v.emplace_back(::variants::Simple{"simple1"});
         v.emplace_back(::variants::Simple{"simple2"});
 
@@ -1438,7 +1445,7 @@ TEST_CASE("Serialization: variant", "[FBE]") {
     }
 
     SECTION ("vector of primitive type") {
-        stdb::container::stdb_vector<int32_t> v {1,2,3};
+        FastVec<int32_t> v {1,2,3};
 
         ::variants::Value value;
         REQUIRE(value.v.index() == 0);
@@ -1497,8 +1504,8 @@ TEST_CASE("Serialization: variant", "[FBE]") {
     }
 
     SECTION ("container of bytes") {
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
-        stdb::container::stdb_vector<FBE::buffer_t> bytes_v;
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<FBE::buffer_t> bytes_v;
         bytes_v.emplace_back(FBE::buffer_t(v));
 
         ::variants::Value value;
@@ -1526,7 +1533,7 @@ TEST_CASE("Serialization: variant", "[FBE]") {
     }
     
     SECTION ("vector of string") {
-        stdb::container::stdb_vector<stdb::memory::string> string_v {"hello", "world"};
+        FastVec<stdb::memory::string> string_v {"hello", "world"};
 
         ::variants::Value value;
         REQUIRE(value.v.index() == 0);
@@ -1555,7 +1562,7 @@ TEST_CASE("Serialization: variant", "[FBE]") {
 
     SECTION ("hash with primitive and bytes") {
         std::unordered_map<int32_t, FBE::buffer_t> m;
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
         m.emplace(42, FBE::buffer_t(v));
 
         ::variants::Value value;
@@ -1584,7 +1591,7 @@ TEST_CASE("Serialization: variant", "[FBE]") {
 
     SECTION ("hash with string and bytes") {
         std::unordered_map<stdb::memory::string, FBE::buffer_t> m;
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
         m.emplace("hello world", FBE::buffer_t(v));
 
         ::variants::Value value;

--- a/tests/test_serialization_final.cpp
+++ b/tests/test_serialization_final.cpp
@@ -7,6 +7,13 @@
 #include "../proto/proto_final_models.h"
 #include "../proto/test_final_models.h"
 
+template <typename T>
+#if defined(USING_STD_VECTOR)
+using FastVec = std::vector<T>;
+#else
+using FastVec = stdb::container::stdb_vector<T>;
+#endif
+
 TEST_CASE("Serialization (Final): domain", "[FBE][.]")
 {
     // Create a new account with some orders
@@ -740,9 +747,9 @@ TEST_CASE("Serialization (Final): struct array", "[FBE][.]")
     struct1.f1[1] = (uint8_t)65;
     struct1.f2[0] = (uint8_t)97;
     struct1.f2[1] = std::nullopt;
-    struct1.f3[0] = stdb::container::stdb_vector<uint8_t>(3, 48);
-    struct1.f3[1] = stdb::container::stdb_vector<uint8_t>(3, 65);
-    struct1.f4[0] = stdb::container::stdb_vector<uint8_t>(3, 97);
+    struct1.f3[0] = FastVec<uint8_t>(3, 48);
+    struct1.f3[1] = FastVec<uint8_t>(3, 65);
+    struct1.f4[0] = FastVec<uint8_t>(3, 97);
     struct1.f4[1] = std::nullopt;
     struct1.f5[0] = test::EnumSimple::ENUM_VALUE_1;
     struct1.f5[1] = test::EnumSimple::ENUM_VALUE_2;
@@ -835,9 +842,9 @@ TEST_CASE("Serialization (Final): struct vector", "[FBE][.]")
     struct1.f1.emplace_back((uint8_t)65);
     struct1.f2.emplace_back((uint8_t)97);
     struct1.f2.emplace_back(std::nullopt);
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace_back(FastVec<uint8_t>(3, 97));
     struct1.f4.emplace_back(std::nullopt);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_2);
@@ -930,9 +937,9 @@ TEST_CASE("Serialization (Final): struct list", "[FBE][.]")
     struct1.f1.emplace_back((uint8_t)65);
     struct1.f2.emplace_back((uint8_t)97);
     struct1.f2.emplace_back(std::nullopt);
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace_back(stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace_back(FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace_back(FastVec<uint8_t>(3, 97));
     struct1.f4.emplace_back(std::nullopt);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace_back(test::EnumSimple::ENUM_VALUE_2);
@@ -1079,9 +1086,9 @@ TEST_CASE("Serialization (Final): struct map", "[FBE][.]")
     struct1.f1.emplace(20, (uint8_t)65);
     struct1.f2.emplace(10, (uint8_t)97);
     struct1.f2.emplace(20, std::nullopt);
-    struct1.f3.emplace(10, stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace(20, stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace(10, stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace(10, FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace(20, FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace(10, FastVec<uint8_t>(3, 97));
     struct1.f4.emplace(20, std::nullopt);
     struct1.f5.emplace(10, test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace(20, test::EnumSimple::ENUM_VALUE_2);
@@ -1161,9 +1168,9 @@ TEST_CASE("Serialization (Final): struct hash", "[FBE][.]")
     struct1.f1.emplace("20", (uint8_t)65);
     struct1.f2.emplace("10", (uint8_t)97);
     struct1.f2.emplace("20", std::nullopt);
-    struct1.f3.emplace("10", stdb::container::stdb_vector<uint8_t>(3, 48));
-    struct1.f3.emplace("20", stdb::container::stdb_vector<uint8_t>(3, 65));
-    struct1.f4.emplace("10", stdb::container::stdb_vector<uint8_t>(3, 97));
+    struct1.f3.emplace("10", FastVec<uint8_t>(3, 48));
+    struct1.f3.emplace("20", FastVec<uint8_t>(3, 65));
+    struct1.f4.emplace("10", FastVec<uint8_t>(3, 97));
     struct1.f4.emplace("20", std::nullopt);
     struct1.f5.emplace("10", test::EnumSimple::ENUM_VALUE_1);
     struct1.f5.emplace("20", test::EnumSimple::ENUM_VALUE_2);

--- a/tests/test_serialization_ptr.cpp
+++ b/tests/test_serialization_ptr.cpp
@@ -28,20 +28,27 @@
 #include <iostream>
 #include <vector>
 
+template <typename T>
+#if defined(USING_STD_VECTOR)
+using FastVec = std::vector<T>;
+#else
+using FastVec = stdb::container::stdb_vector<T>;
+#endif
+
 TEST_CASE("Serialization (simple self-reference)", "[Ptr-based FBE]")
 {
-    stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>> v;
+    FastVec<std::unique_ptr<::simple::Simple>> v;
     v.push_back(std::make_unique<::simple::Simple>(::simple::Simple(
-        "v-info", nullptr, 1024, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>>(),
-        stdb::container::stdb_vector<::simple::Simple>(),
+        "v-info", nullptr, 1024, FastVec<std::unique_ptr<::simple::Simple>>(),
+        FastVec<::simple::Simple>(),
         std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
         std::map<int32_t, ::simple::Simple>())));
 
     auto simplep = std::make_unique<::simple::Simple>(
         ::simple::Simple(
             "single-info", nullptr, 2048,
-            stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>>(),
-            stdb::container::stdb_vector<::simple::Simple>(),
+            FastVec<std::unique_ptr<::simple::Simple>>(),
+            FastVec<::simple::Simple>(),
             std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
             std::map<int32_t, ::simple::Simple>()
         )
@@ -59,20 +66,20 @@ TEST_CASE("Serialization (simple self-reference)", "[Ptr-based FBE]")
                     "info 3",
                     std::make_unique<::simple::Simple>( 
                         "info 4", nullptr, 4, std::move(v),
-                        stdb::container::stdb_vector<::simple::Simple>(),
+                        FastVec<::simple::Simple>(),
                         std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
                         std::map<int32_t, ::simple::Simple>()
                     ),
-                    3, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>>(),
-                    stdb::container::stdb_vector<::simple::Simple>(),
+                    3, FastVec<std::unique_ptr<::simple::Simple>>(),
+                    FastVec<::simple::Simple>(),
                     std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
                     std::map<int32_t, ::simple::Simple>())),
-                2, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>>(),
-                stdb::container::stdb_vector<::simple::Simple>(),
+                2, FastVec<std::unique_ptr<::simple::Simple>>(),
+                FastVec<::simple::Simple>(),
                 std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
                 std::map<int32_t, ::simple::Simple>())),
-            1, stdb::container::stdb_vector<std::unique_ptr<::simple::Simple>>(),
-            stdb::container::stdb_vector<::simple::Simple>(),
+            1, FastVec<std::unique_ptr<::simple::Simple>>(),
+            FastVec<::simple::Simple>(),
             std::map<int32_t, std::unique_ptr<::simple::Simple>>(),
             std::map<int32_t, ::simple::Simple>()),
         10,
@@ -163,14 +170,14 @@ TEST_CASE("Serialization (extra circular-dependency)", "[Ptr-based FBE]")
                 ::extra::Info("v-embedded-struct-info-data", nullptr, {}, {})),
             std::make_unique<::extra::Info>(
                 ::extra::Info("v-embedded-struct-info2-data", nullptr, {}, {})),
-            std::move(embedded_info), stdb::container::stdb_vector<::extra::Info>(),
-            stdb::container::stdb_vector<std::unique_ptr<::extra::Info>>(),
+            std::move(embedded_info), FastVec<::extra::Info>(),
+            FastVec<std::unique_ptr<::extra::Info>>(),
             std::list<::extra::Info>(),
             std::list<std::unique_ptr<::extra::Info>>()),
         {},
         {}};
-    stdb::container::stdb_vector<::extra::Info> v;
-    stdb::container::stdb_vector<std::unique_ptr<::extra::Info>> pv;
+    FastVec<::extra::Info> v;
+    FastVec<std::unique_ptr<::extra::Info>> pv;
     v.emplace_back(std::move(embedded_info3));
     pv.emplace_back(std::make_unique<::extra::Info>(::extra::Info(
         "pv-info-data",
@@ -180,8 +187,8 @@ TEST_CASE("Serialization (extra circular-dependency)", "[Ptr-based FBE]")
                 ::extra::Info("pv-embedded-struct-info-data", nullptr, {}, {})),
             std::make_unique<::extra::Info>(
                 ::extra::Info("pv-embedded-struct-info2-data", nullptr, {}, {})),
-            std::move(embedded_info2), stdb::container::stdb_vector<::extra::Info>(),
-            stdb::container::stdb_vector<std::unique_ptr<::extra::Info>>(),
+            std::move(embedded_info2), FastVec<::extra::Info>(),
+            FastVec<std::unique_ptr<::extra::Info>>(),
             std::list<::extra::Info>(),
             std::list<std::unique_ptr<::extra::Info>>()),
         {}, {})));
@@ -558,7 +565,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
 
     SECTION ("vector of struct") {
-        stdb::container::stdb_vector<::variants_ptr::Simple> v;
+        FastVec<::variants_ptr::Simple> v;
         v.emplace_back(::variants_ptr::Simple{"simple1"});
         v.emplace_back(::variants_ptr::Simple{"simple2"});
 
@@ -588,7 +595,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
 
     SECTION ("vector of primitive type") {
-        stdb::container::stdb_vector<int32_t> v {1,2,3};
+        FastVec<int32_t> v {1,2,3};
 
         ::variants_ptr::Value value;
         REQUIRE(value.v.index() == 0);
@@ -647,8 +654,8 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
     
     SECTION ("container of bytes") {
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
-        stdb::container::stdb_vector<FBE::buffer_t> bytes_v;
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<FBE::buffer_t> bytes_v;
         bytes_v.emplace_back(FBE::buffer_t(v));
 
         ::variants_ptr::Value value;
@@ -676,7 +683,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
     
     SECTION ("vector of string") {
-        stdb::container::stdb_vector<stdb::memory::string> string_v {"hello", "world"};
+        FastVec<stdb::memory::string> string_v {"hello", "world"};
 
         ::variants_ptr::Value value;
         REQUIRE(value.v.index() == 0);
@@ -705,7 +712,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
 
     SECTION ("hash with primitive and bytes") {
         std::unordered_map<int32_t, FBE::buffer_t> m;
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
         m.emplace(42, FBE::buffer_t(v));
 
         ::variants_ptr::Value value;
@@ -734,7 +741,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
 
     SECTION ("hash with string and bytes") {
         std::unordered_map<stdb::memory::string, FBE::buffer_t> m;
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
         m.emplace("hello world", FBE::buffer_t(v));
 
         ::variants_ptr::Value value;
@@ -762,7 +769,7 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
 
     SECTION ("vector of pointer") {
-        stdb::container::stdb_vector<::variants_ptr::Simple*> v;
+        FastVec<::variants_ptr::Simple*> v;
         auto simple1 = std::make_unique<::variants_ptr::Simple>("simple1");
         auto simple2 = std::make_unique<::variants_ptr::Simple>("simple2");
         v.emplace_back(simple1.get());
@@ -877,11 +884,11 @@ TEST_CASE("Serialization (import template)", "[Ptr-based FBE]") {
         ::variants::Expr expr {"42"};
         line.v.emplace<::variants::Expr>(std::move(expr));
 
-        stdb::container::stdb_vector<::variants::Simple> vs;
+        FastVec<::variants::Simple> vs;
         vs.emplace_back(::variants::Simple{"simple1"});
         vs.emplace_back(::variants::Simple{"simple2"});\
         ::variants::V v1;
-        v1.emplace<stdb::container::stdb_vector<::variants::Simple>>(std::move(vs));
+        v1.emplace<FastVec<::variants::Simple>>(std::move(vs));
         line.vv.emplace_back(std::move(v1));
         ::variants::V v2 {stdb::memory::string("hello")};
         line.vv.emplace_back(std::move(v2));
@@ -908,10 +915,10 @@ TEST_CASE("Serialization (import template)", "[Ptr-based FBE]") {
 
         REQUIRE(std::holds_alternative<::variants::Expr>(line_copy.v));
         REQUIRE(line_copy.vv.size() == 2);
-        REQUIRE(std::holds_alternative<stdb::container::stdb_vector<::variants::Simple>>(line_copy.vv.at(0)));
-        REQUIRE(std::get<stdb::container::stdb_vector<::variants::Simple>>(line_copy.vv.at(0)).size() == 2);
-        REQUIRE(std::get<stdb::container::stdb_vector<::variants::Simple>>(line_copy.vv.at(0)).at(0).name == "simple1");
-        REQUIRE(std::get<stdb::container::stdb_vector<::variants::Simple>>(line_copy.vv.at(0)).at(1).name == "simple2");
+        REQUIRE(std::holds_alternative<FastVec<::variants::Simple>>(line_copy.vv.at(0)));
+        REQUIRE(std::get<FastVec<::variants::Simple>>(line_copy.vv.at(0)).size() == 2);
+        REQUIRE(std::get<FastVec<::variants::Simple>>(line_copy.vv.at(0)).at(0).name == "simple1");
+        REQUIRE(std::get<FastVec<::variants::Simple>>(line_copy.vv.at(0)).at(1).name == "simple2");
         REQUIRE(std::holds_alternative<stdb::memory::string>(line_copy.vv.at(1)));
         REQUIRE(std::get<stdb::memory::string>(line_copy.vv.at(1)) == "hello");
         REQUIRE(std::holds_alternative<stdb::memory::string>(line_copy.vv.at(1)));
@@ -957,8 +964,8 @@ TEST_CASE("Serialization (import template)", "[Ptr-based FBE]") {
     SECTION("struct") {
         ::template_variant::Line3 line;
 
-        stdb::container::stdb_vector<uint8_t> v {65, 66, 67, 68, 69};
-        stdb::container::stdb_vector<FBE::buffer_t> bytes_v;
+        FastVec<uint8_t> v {65, 66, 67, 68, 69};
+        FastVec<FBE::buffer_t> bytes_v;
         bytes_v.emplace_back(FBE::buffer_t(v));
 
         REQUIRE(line.value.v.index() == 0);


### PR DESCRIPTION
`cmake -DFBE_USING_STD_VECTOR =ON` will using `std::vector` instead of `stdb_vector`.

stdb_vector version does not work until the iterator is changed to snake_case, which is consistent with STL.
 