### PR TITLE
from_json support non-existence fields in json str

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "modules/memory"]
 	path = modules/memory
 	url = https://github.com/stdbio/memory.git
+[submodule "modules/rapidjson"]
+	path = modules/rapidjson
+	url = https://github.com/Tencent/rapidjson.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,13 @@ find_package(LibUUID)
 
 include_directories("modules/memory")
 include_directories("modules/Catch2/single_include")
+include_directories("modules/rapidjson/include")
 
 
 # Modules
 add_subdirectory("modules/Catch2")
 add_subdirectory("modules/memory")
+add_subdirectory("modules/rapidjson")
 
 # Link libraries
 #list(APPEND LINKLIBS cppcommon)

--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -6562,7 +6562,8 @@ struct NodeReader
         // Try to find a member with the given key
         rapidjson::Value::ConstMemberIterator member = json.FindMember(key);
         if (member == json.MemberEnd())
-            return false;
+            // omitted field in json str is allowed.
+            return true;
 
         return FBE::JSON::from_json(member->value, value);
     }

--- a/pkg-dependency.sh
+++ b/pkg-dependency.sh
@@ -27,7 +27,6 @@ fbe_fedora_packages=(
     ninja-build
     zlib-static
     xxhash-devel
-    rapidjson-devel
     uuid-devel
     google-benchmark-devel
 )
@@ -52,12 +51,10 @@ fbe_debian_packages=(
     libxxhash-dev
     libboost-dev
     libfmt-dev
-    rapidjson-dev
     libbenchmark-dev
 )
 
 fbe_darwin_packages=(
-    rapidjson
     cmake
     ninja
     fmt

--- a/proto/fbe_json.h
+++ b/proto/fbe_json.h
@@ -1028,7 +1028,8 @@ struct NodeReader
         // Try to find a member with the given key
         rapidjson::Value::ConstMemberIterator member = json.FindMember(key);
         if (member == json.MemberEnd())
-            return false;
+            // omitted field in json str is allowed.
+            return true;
 
         return FBE::JSON::from_json(member->value, value);
     }

--- a/proto/proto.cpp
+++ b/proto/proto.cpp
@@ -425,4 +425,81 @@ std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const AccountMes
     return stream;
 }
 
+PremiumAccount::PremiumAccount()
+    : id((int32_t)0ll)
+    , name()
+    , info()
+    , private_wallet()
+    , private_orders()
+    , private_state(State::bad)
+{}
+
+PremiumAccount::PremiumAccount(int32_t arg_id, const stdb::memory::string& arg_name, const stdb::memory::string& arg_info, const ::proto::Balance& arg_private_wallet, const FastVec<::proto::Order>& arg_private_orders, const ::proto::State& arg_private_state)
+    : id(arg_id)
+    , name(arg_name)
+    , info(arg_info)
+    , private_wallet(arg_private_wallet)
+    , private_orders(arg_private_orders)
+    , private_state(arg_private_state)
+{}
+
+bool PremiumAccount::operator==([[maybe_unused]] const PremiumAccount& other) const noexcept
+{
+    return (
+        (id == other.id)
+        && (name == other.name)
+        && (info == other.info)
+        && (private_wallet == other.private_wallet)
+        && (private_orders == other.private_orders)
+        && (private_state == other.private_state)
+        );
+}
+
+bool PremiumAccount::operator<([[maybe_unused]] const PremiumAccount& other) const noexcept
+{
+    if (id < other.id)
+        return true;
+    if (other.id < id)
+        return false;
+    return false;
+}
+
+std::string PremiumAccount::string() const
+{
+    std::stringstream ss; ss << *this; return ss.str();
+}
+
+void PremiumAccount::swap([[maybe_unused]] PremiumAccount& other) noexcept
+{
+    using std::swap;
+    swap(id, other.id);
+    swap(name, other.name);
+    swap(info, other.info);
+    swap(private_wallet, other.private_wallet);
+    swap(private_orders, other.private_orders);
+    swap(private_state, other.private_state);
+}
+
+std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const PremiumAccount& value)
+{
+    stream << "PremiumAccount(";
+    stream << "id="; stream << value.id;
+    stream << ",name="; stream << "\"" << value.name << "\"";
+    stream << ",info="; stream << "\"" << value.info << "\"";
+    stream << ",private_wallet="; stream << value.private_wallet;
+    {
+        bool first = true;
+        stream << ",private_orders=[" << value.private_orders.size() << "][";
+        for (const auto& it : value.private_orders)
+        {
+            stream << std::string(first ? "" : ",") << it;
+            first = false;
+        }
+        stream << "]";
+    }
+    stream << ",private_state="; stream << value.private_state;
+    stream << ")";
+    return stream;
+}
+
 } // namespace proto

--- a/proto/proto.fbe
+++ b/proto/proto.fbe
@@ -89,3 +89,12 @@ message AccountMessage
 {
     Account body;
 }
+
+struct PremiumAccount {
+    [key] int32 id;
+    string name;
+    string info; // test skipping empty field.
+    Balance private_wallet; // test skipping empty filed
+    Order[] private_orders; // test skipping empty filed
+    State private_state = State.bad; // test skipping empty filed
+}

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -418,4 +418,57 @@ struct std::hash<proto::AccountMessage>
 
 namespace proto {
 
+struct PremiumAccount
+{
+    int32_t id;
+    stdb::memory::string name;
+    stdb::memory::string info;
+    ::proto::Balance private_wallet;
+    FastVec<::proto::Order> private_orders;
+    ::proto::State private_state;
+
+    size_t fbe_type() const noexcept { return 5; }
+
+    PremiumAccount();
+    PremiumAccount(int32_t arg_id, const stdb::memory::string& arg_name, const stdb::memory::string& arg_info, const ::proto::Balance& arg_private_wallet, const FastVec<::proto::Order>& arg_private_orders, const ::proto::State& arg_private_state);
+    PremiumAccount(const PremiumAccount& other) = default;
+    PremiumAccount(PremiumAccount&& other) = default;
+    ~PremiumAccount() = default;
+
+    PremiumAccount& operator=(const PremiumAccount& other) = default;
+    PremiumAccount& operator=(PremiumAccount&& other) = default;
+
+    bool operator==(const PremiumAccount& other) const noexcept;
+    bool operator!=(const PremiumAccount& other) const noexcept { return !operator==(other); }
+    bool operator<(const PremiumAccount& other) const noexcept;
+    bool operator<=(const PremiumAccount& other) const noexcept { return operator<(other) || operator==(other); }
+    bool operator>(const PremiumAccount& other) const noexcept { return !operator<=(other); }
+    bool operator>=(const PremiumAccount& other) const noexcept { return !operator<(other); }
+
+    std::string string() const;
+
+    friend std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const PremiumAccount& value);
+
+    void swap(PremiumAccount& other) noexcept;
+    friend void swap(PremiumAccount& value1, PremiumAccount& value2) noexcept { value1.swap(value2); }
+};
+
+} // namespace proto
+
+template<>
+struct std::hash<proto::PremiumAccount>
+{
+    typedef proto::PremiumAccount argument_type;
+    typedef size_t result_type;
+
+    result_type operator() ([[maybe_unused]] const argument_type& value) const
+    {
+        result_type result = 17;
+        result = result * 31 + std::hash<decltype(value.id)>()(value.id);
+        return result;
+    }
+};
+
+namespace proto {
+
 } // namespace proto

--- a/proto/proto_final_models.cpp
+++ b/proto/proto_final_models.cpp
@@ -1117,4 +1117,224 @@ size_t AccountMessageFinalModel::deserialize(::proto::AccountMessage& value) con
 
 } // namespace proto
 
+FinalModel<::proto::PremiumAccount>::FinalModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset)
+    , id(buffer, 0)
+    , name(buffer, 0)
+    , info(buffer, 0)
+    , private_wallet(buffer, 0)
+    , private_orders(buffer, 0)
+    , private_state(buffer, 0)
+{}
+
+size_t FinalModel<::proto::PremiumAccount>::fbe_allocation_size(const ::proto::PremiumAccount& fbe_value) const noexcept
+{
+    size_t fbe_result = 0
+        + id.fbe_allocation_size(fbe_value.id)
+        + name.fbe_allocation_size(fbe_value.name)
+        + info.fbe_allocation_size(fbe_value.info)
+        + private_wallet.fbe_allocation_size(fbe_value.private_wallet)
+        + private_orders.fbe_allocation_size(fbe_value.private_orders)
+        + private_state.fbe_allocation_size(fbe_value.private_state)
+        ;
+    return fbe_result;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::verify() const noexcept
+{
+    _buffer.shift(fbe_offset());
+    size_t fbe_result = verify_fields();
+    _buffer.unshift(fbe_offset());
+    return fbe_result;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::verify_fields() const noexcept
+{
+    size_t fbe_current_offset = 0;
+    size_t fbe_field_size;
+
+    id.fbe_offset(fbe_current_offset);
+    fbe_field_size = id.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    name.fbe_offset(fbe_current_offset);
+    fbe_field_size = name.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    info.fbe_offset(fbe_current_offset);
+    fbe_field_size = info.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    private_wallet.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_wallet.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    private_orders.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_orders.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    private_state.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_state.verify();
+    if (fbe_field_size == std::numeric_limits<std::size_t>::max())
+        return std::numeric_limits<std::size_t>::max();
+    fbe_current_offset += fbe_field_size;
+
+    return fbe_current_offset;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::get(::proto::PremiumAccount& fbe_value) const noexcept
+{
+    _buffer.shift(fbe_offset());
+    size_t fbe_result = get_fields(fbe_value);
+    _buffer.unshift(fbe_offset());
+    return fbe_result;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::get_fields([[maybe_unused]] ::proto::PremiumAccount& fbe_value) const noexcept
+{
+    size_t fbe_current_offset = 0;
+    size_t fbe_current_size = 0;
+    size_t fbe_field_size;
+
+    id.fbe_offset(fbe_current_offset);
+    fbe_field_size = id.get(fbe_value.id);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    name.fbe_offset(fbe_current_offset);
+    fbe_field_size = name.get(fbe_value.name);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    info.fbe_offset(fbe_current_offset);
+    fbe_field_size = info.get(fbe_value.info);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_wallet.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_wallet.get(fbe_value.private_wallet);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_orders.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_orders.get(fbe_value.private_orders);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_state.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_state.get(fbe_value.private_state);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    return fbe_current_size;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::set(const ::proto::PremiumAccount& fbe_value) noexcept
+{
+    _buffer.shift(fbe_offset());
+    size_t fbe_result = set_fields(fbe_value);
+    _buffer.unshift(fbe_offset());
+    return fbe_result;
+}
+
+size_t FinalModel<::proto::PremiumAccount>::set_fields([[maybe_unused]] const ::proto::PremiumAccount& fbe_value) noexcept
+{
+    size_t fbe_current_offset = 0;
+    size_t fbe_current_size = 0;
+    size_t fbe_field_size;
+
+    id.fbe_offset(fbe_current_offset);
+    fbe_field_size = id.set(fbe_value.id);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    name.fbe_offset(fbe_current_offset);
+    fbe_field_size = name.set(fbe_value.name);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    info.fbe_offset(fbe_current_offset);
+    fbe_field_size = info.set(fbe_value.info);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_wallet.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_wallet.set(fbe_value.private_wallet);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_orders.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_orders.set(fbe_value.private_orders);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    private_state.fbe_offset(fbe_current_offset);
+    fbe_field_size = private_state.set(fbe_value.private_state);
+    fbe_current_offset += fbe_field_size;
+    fbe_current_size += fbe_field_size;
+
+    return fbe_current_size;
+}
+
+namespace proto {
+
+bool PremiumAccountFinalModel::verify()
+{
+    if ((this->buffer().offset() + _model.fbe_offset()) > this->buffer().size())
+        return false;
+
+    size_t fbe_struct_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 8);
+    size_t fbe_struct_type = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 4);
+    if ((fbe_struct_size == 0) || (fbe_struct_type != fbe_type()))
+        return false;
+
+    return ((8 + _model.verify()) == fbe_struct_size);
+}
+
+size_t PremiumAccountFinalModel::serialize(const ::proto::PremiumAccount& value)
+{
+    size_t fbe_initial_size = this->buffer().size();
+
+    uint32_t fbe_struct_type = (uint32_t)fbe_type();
+    uint32_t fbe_struct_size = (uint32_t)(8 + _model.fbe_allocation_size(value));
+    uint32_t fbe_struct_offset = (uint32_t)(this->buffer().allocate(fbe_struct_size) - this->buffer().offset());
+    assert(((this->buffer().offset() + fbe_struct_offset + fbe_struct_size) <= this->buffer().size()) && "Model is broken!");
+    if ((this->buffer().offset() + fbe_struct_offset + fbe_struct_size) > this->buffer().size())
+        return 0;
+
+    fbe_struct_size = (uint32_t)(8 + _model.set(value));
+    this->buffer().resize(fbe_initial_size + fbe_struct_size);
+
+    *((uint32_t*)(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 8)) = fbe_struct_size;
+    *((uint32_t*)(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 4)) = fbe_struct_type;
+
+    return fbe_struct_size;
+}
+
+size_t PremiumAccountFinalModel::deserialize(::proto::PremiumAccount& value) const noexcept
+{
+    assert(((this->buffer().offset() + _model.fbe_offset()) <= this->buffer().size()) && "Model is broken!");
+    if ((this->buffer().offset() + _model.fbe_offset()) > this->buffer().size())
+        return 0;
+
+    size_t fbe_struct_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 8);
+    size_t fbe_struct_type = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + _model.fbe_offset() - 4);
+    assert(((fbe_struct_size > 0) && (fbe_struct_type == fbe_type())) && "Model is broken!");
+    if ((fbe_struct_size == 0) || (fbe_struct_type != fbe_type()))
+        return 8;
+
+    return 8 + _model.get(value);
+}
+
+} // namespace proto
+
 } // namespace FBE

--- a/proto/proto_final_models.h
+++ b/proto/proto_final_models.h
@@ -571,4 +571,82 @@ private:
 
 } // namespace proto
 
+// Fast Binary Encoding ::proto::PremiumAccount final model
+template <>
+class FinalModel<::proto::PremiumAccount>
+{
+public:
+    FinalModel(FBEBuffer& buffer, size_t offset) noexcept;
+
+    // Get the allocation size
+    size_t fbe_allocation_size(const ::proto::PremiumAccount& fbe_value) const noexcept;
+    // Get the final offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Set the final offset
+    size_t fbe_offset(size_t offset) const noexcept { return _offset = offset; }
+    // Get the final type
+    static constexpr size_t fbe_type() noexcept { return 5; }
+
+    // Shift the current final offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current final offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the struct value is valid
+    size_t verify() const noexcept;
+    // Check if the struct fields are valid
+    size_t verify_fields() const noexcept;
+
+    // Get the struct value
+    size_t get(::proto::PremiumAccount& fbe_value) const noexcept;
+    // Get the struct fields values
+    size_t get_fields(::proto::PremiumAccount& fbe_value) const noexcept;
+
+    // Set the struct value
+    size_t set(const ::proto::PremiumAccount& fbe_value) noexcept;
+    // Set the struct fields values
+    size_t set_fields(const ::proto::PremiumAccount& fbe_value) noexcept;
+
+private:
+    FBEBuffer& _buffer;
+    mutable size_t _offset;
+
+public:
+    FinalModel<int32_t> id;
+    FinalModel<stdb::memory::string> name;
+    FinalModel<stdb::memory::string> info;
+    FinalModel<::proto::Balance> private_wallet;
+    FinalModelVector<::proto::Order> private_orders;
+    FinalModel<::proto::State> private_state;
+};
+
+namespace proto {
+
+// Fast Binary Encoding PremiumAccount final model
+class PremiumAccountFinalModel : public FBE::Model
+{
+public:
+    PremiumAccountFinalModel() : _model(this->buffer(), 8) {}
+    PremiumAccountFinalModel(const std::shared_ptr<FBEBuffer>& buffer) : FBE::Model(buffer), _model(this->buffer(), 8) {}
+
+    // Get the model type
+    static constexpr size_t fbe_type() noexcept { return FinalModel<::proto::PremiumAccount>::fbe_type(); }
+
+    // Check if the struct value is valid
+    bool verify();
+
+    // Serialize the struct value
+    size_t serialize(const ::proto::PremiumAccount& value);
+    // Deserialize the struct value
+    size_t deserialize(::proto::PremiumAccount& value) const noexcept;
+
+    // Move to the next struct value
+    void next(size_t prev) noexcept { _model.fbe_shift(prev); }
+
+private:
+    FinalModel<::proto::PremiumAccount> _model;
+};
+
+} // namespace proto
+
 } // namespace FBE

--- a/proto/proto_json.h
+++ b/proto/proto_json.h
@@ -339,6 +339,51 @@ struct ValueReader<TJson, ::proto::AccountMessage>
     }
 };
 
+template <class TWriter>
+struct ValueWriter<TWriter, ::proto::PremiumAccount>
+{
+    static bool to_json(TWriter& writer, const ::proto::PremiumAccount& value, bool scope = true)
+    {
+        if (scope)
+            if (!writer.StartObject())
+                return false;
+        if (!FBE::JSON::to_json_key(writer, "id") || !FBE::JSON::to_json(writer, value.id, true))
+            return false;
+        if (!FBE::JSON::to_json_key(writer, "name") || !FBE::JSON::to_json(writer, value.name, true))
+            return false;
+        if (!FBE::JSON::to_json_key(writer, "info") || !FBE::JSON::to_json(writer, value.info, true))
+            return false;
+        if (!FBE::JSON::to_json_key(writer, "private_wallet") || !FBE::JSON::to_json(writer, value.private_wallet, true))
+            return false;
+        if (!FBE::JSON::to_json_key(writer, "private_orders") || !FBE::JSON::to_json(writer, value.private_orders, true))
+            return false;
+        if (!FBE::JSON::to_json_key(writer, "private_state") || !FBE::JSON::to_json(writer, value.private_state, true))
+            return false;
+        if (scope)
+            if (!writer.EndObject())
+                return false;
+        return true;
+    }
+};
+
+template <class TJson>
+struct ValueReader<TJson, ::proto::PremiumAccount>
+{
+    static bool from_json(const TJson& json, ::proto::PremiumAccount& value, const char* key = nullptr)
+    {
+        if (key != nullptr)
+            return FBE::JSON::from_json_child(json, value, key);
+        bool result = true;
+        result &= FBE::JSON::from_json(json, value.id, "id");
+        result &= FBE::JSON::from_json(json, value.name, "name");
+        result &= FBE::JSON::from_json(json, value.info, "info");
+        result &= FBE::JSON::from_json(json, value.private_wallet, "private_wallet");
+        result &= FBE::JSON::from_json(json, value.private_orders, "private_orders");
+        result &= FBE::JSON::from_json(json, value.private_state, "private_state");
+        return result;
+    }
+};
+
 } // namespace JSON
 
 } // namespace FBE

--- a/proto/proto_models.cpp
+++ b/proto/proto_models.cpp
@@ -1627,4 +1627,290 @@ size_t AccountMessageModel::deserialize(::proto::AccountMessage& value) const no
 
 } // namespace proto
 
+FieldModel<::proto::PremiumAccount>::FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset)
+    , id(buffer, 4 + 4)
+    , name(buffer, id.fbe_offset() + id.fbe_size())
+    , info(buffer, name.fbe_offset() + name.fbe_size())
+    , private_wallet(buffer, info.fbe_offset() + info.fbe_size())
+    , private_orders(buffer, private_wallet.fbe_offset() + private_wallet.fbe_size())
+    , private_state(buffer, private_orders.fbe_offset() + private_orders.fbe_size())
+{}
+
+size_t FieldModel<::proto::PremiumAccount>::fbe_body() const noexcept
+{
+    size_t fbe_result = 4 + 4
+        + id.fbe_size()
+        + name.fbe_size()
+        + info.fbe_size()
+        + private_wallet.fbe_size()
+        + private_orders.fbe_size()
+        + private_state.fbe_size()
+        ;
+    return fbe_result;
+}
+
+size_t FieldModel<::proto::PremiumAccount>::fbe_extra() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4) > _buffer.size()))
+        return 0;
+
+    _buffer.shift(fbe_struct_offset);
+
+    size_t fbe_result = fbe_body()
+        + id.fbe_extra()
+        + name.fbe_extra()
+        + info.fbe_extra()
+        + private_wallet.fbe_extra()
+        + private_orders.fbe_extra()
+        + private_state.fbe_extra()
+        ;
+
+    _buffer.unshift(fbe_struct_offset);
+
+    return fbe_result;
+}
+
+bool FieldModel<::proto::PremiumAccount>::verify(bool fbe_verify_type) const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return true;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4 + 4) > _buffer.size()))
+        return false;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset);
+    if (fbe_struct_size < (4 + 4))
+        return false;
+
+    uint32_t fbe_struct_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset + 4);
+    if (fbe_verify_type && (fbe_struct_type != fbe_type()))
+        return false;
+
+    _buffer.shift(fbe_struct_offset);
+    bool fbe_result = verify_fields(fbe_struct_size);
+    _buffer.unshift(fbe_struct_offset);
+    return fbe_result;
+}
+
+bool FieldModel<::proto::PremiumAccount>::verify_fields([[maybe_unused]] size_t fbe_struct_size) const noexcept
+{
+    size_t fbe_current_size = 4 + 4;
+
+    if ((fbe_current_size + id.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!id.verify())
+        return false;
+    fbe_current_size += id.fbe_size();
+
+    if ((fbe_current_size + name.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!name.verify())
+        return false;
+    fbe_current_size += name.fbe_size();
+
+    if ((fbe_current_size + info.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!info.verify())
+        return false;
+    fbe_current_size += info.fbe_size();
+
+    if ((fbe_current_size + private_wallet.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_wallet.verify())
+        return false;
+    fbe_current_size += private_wallet.fbe_size();
+
+    if ((fbe_current_size + private_orders.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_orders.verify())
+        return false;
+    fbe_current_size += private_orders.fbe_size();
+
+    if ((fbe_current_size + private_state.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_state.verify())
+        return false;
+    fbe_current_size += private_state.fbe_size();
+
+    return true;
+}
+
+size_t FieldModel<::proto::PremiumAccount>::get_begin() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    assert(((fbe_struct_offset > 0) && ((_buffer.offset() + fbe_struct_offset + 4 + 4) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4 + 4) > _buffer.size()))
+        return 0;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset);
+    assert((fbe_struct_size >= (4 + 4)) && "Model is broken!");
+    if (fbe_struct_size < (4 + 4))
+        return 0;
+
+    _buffer.shift(fbe_struct_offset);
+    return fbe_struct_offset;
+}
+
+void FieldModel<::proto::PremiumAccount>::get_end(size_t fbe_begin) const noexcept
+{
+    _buffer.unshift(fbe_begin);
+}
+
+void FieldModel<::proto::PremiumAccount>::get(::proto::PremiumAccount& fbe_value) const noexcept
+{
+    size_t fbe_begin = get_begin();
+    if (fbe_begin == 0)
+        return;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset());
+    get_fields(fbe_value, fbe_struct_size);
+    get_end(fbe_begin);
+}
+
+void FieldModel<::proto::PremiumAccount>::get_fields([[maybe_unused]] ::proto::PremiumAccount& fbe_value, [[maybe_unused]] size_t fbe_struct_size) const noexcept
+{
+    size_t fbe_current_size = 4 + 4;
+
+    if ((fbe_current_size + id.fbe_size()) <= fbe_struct_size)
+        id.get(fbe_value.id);
+    else
+        fbe_value.id = (int32_t)0ll;
+    fbe_current_size += id.fbe_size();
+
+    if ((fbe_current_size + name.fbe_size()) <= fbe_struct_size)
+        name.get(fbe_value.name);
+    else
+        fbe_value.name = "";
+    fbe_current_size += name.fbe_size();
+
+    if ((fbe_current_size + info.fbe_size()) <= fbe_struct_size)
+        info.get(fbe_value.info);
+    else
+        fbe_value.info = "";
+    fbe_current_size += info.fbe_size();
+
+    if ((fbe_current_size + private_wallet.fbe_size()) <= fbe_struct_size)
+        private_wallet.get(fbe_value.private_wallet);
+    else
+        fbe_value.private_wallet = ::proto::Balance();
+    fbe_current_size += private_wallet.fbe_size();
+
+    if ((fbe_current_size + private_orders.fbe_size()) <= fbe_struct_size)
+        private_orders.get(fbe_value.private_orders);
+    else
+        fbe_value.private_orders.clear();
+    fbe_current_size += private_orders.fbe_size();
+
+    if ((fbe_current_size + private_state.fbe_size()) <= fbe_struct_size)
+        private_state.get(fbe_value.private_state, State::bad);
+    else
+        fbe_value.private_state = State::bad;
+    fbe_current_size += private_state.fbe_size();
+}
+
+size_t FieldModel<::proto::PremiumAccount>::set_begin()
+{
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_size = (uint32_t)fbe_body();
+    uint32_t fbe_struct_offset = (uint32_t)(_buffer.allocate(fbe_struct_size) - _buffer.offset());
+    assert(((fbe_struct_offset > 0) && ((_buffer.offset() + fbe_struct_offset + fbe_struct_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + fbe_struct_size) > _buffer.size()))
+        return 0;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_struct_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset, fbe_struct_size);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset + 4, (uint32_t)fbe_type());
+
+    _buffer.shift(fbe_struct_offset);
+    return fbe_struct_offset;
+}
+
+void FieldModel<::proto::PremiumAccount>::set_end(size_t fbe_begin)
+{
+    _buffer.unshift(fbe_begin);
+}
+
+void FieldModel<::proto::PremiumAccount>::set(const ::proto::PremiumAccount& fbe_value) noexcept
+{
+    size_t fbe_begin = set_begin();
+    if (fbe_begin == 0)
+        return;
+
+    set_fields(fbe_value);
+    set_end(fbe_begin);
+}
+
+void FieldModel<::proto::PremiumAccount>::set_fields([[maybe_unused]] const ::proto::PremiumAccount& fbe_value) noexcept
+{
+    id.set(fbe_value.id);
+    name.set(fbe_value.name);
+    info.set(fbe_value.info);
+    private_wallet.set(fbe_value.private_wallet);
+    private_orders.set(fbe_value.private_orders);
+    private_state.set(fbe_value.private_state);
+}
+
+namespace proto {
+
+bool PremiumAccountModel::verify()
+{
+    if ((this->buffer().offset() + model.fbe_offset() - 4) > this->buffer().size())
+        return false;
+
+    uint32_t fbe_full_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4);
+    if (fbe_full_size < model.fbe_size())
+        return false;
+
+    return model.verify();
+}
+
+size_t PremiumAccountModel::create_begin()
+{
+    size_t fbe_begin = this->buffer().allocate(4 + model.fbe_size());
+    return fbe_begin;
+}
+
+size_t PremiumAccountModel::create_end(size_t fbe_begin)
+{
+    size_t fbe_end = this->buffer().size();
+    uint32_t fbe_full_size = (uint32_t)(fbe_end - fbe_begin);
+    unaligned_store<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4, fbe_full_size);
+    return fbe_full_size;
+}
+
+size_t PremiumAccountModel::serialize(const ::proto::PremiumAccount& value)
+{
+    size_t fbe_begin = create_begin();
+    model.set(value);
+    size_t fbe_full_size = create_end(fbe_begin);
+    return fbe_full_size;
+}
+
+size_t PremiumAccountModel::deserialize(::proto::PremiumAccount& value) const noexcept
+{
+    if ((this->buffer().offset() + model.fbe_offset() - 4) > this->buffer().size())
+        return 0;
+
+    uint32_t fbe_full_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4);
+    assert((fbe_full_size >= model.fbe_size()) && "Model is broken!");
+    if (fbe_full_size < model.fbe_size())
+        return 0;
+
+    model.get(value);
+    return fbe_full_size;
+}
+
+} // namespace proto
+
 } // namespace FBE

--- a/proto/proto_models.h
+++ b/proto/proto_models.h
@@ -704,4 +704,101 @@ public:
 
 } // namespace proto
 
+// Fast Binary Encoding ::proto::PremiumAccount field model
+template <>
+class FieldModel<::proto::PremiumAccount>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept;
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field body size
+    size_t fbe_body() const noexcept;
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+    // Get the field type
+    static constexpr size_t fbe_type() noexcept { return 5; }
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the struct value is valid
+    bool verify(bool fbe_verify_type = true) const noexcept;
+    // Check if the struct fields are valid
+    bool verify_fields(size_t fbe_struct_size) const noexcept;
+
+    // Get the struct value (begin phase)
+    size_t get_begin() const noexcept;
+    // Get the struct value (end phase)
+    void get_end(size_t fbe_begin) const noexcept;
+
+    // Get the struct value
+    void get(::proto::PremiumAccount& fbe_value) const noexcept;
+    // Get the struct fields values
+    void get_fields(::proto::PremiumAccount& fbe_value, size_t fbe_struct_size) const noexcept;
+
+    // Set the struct value (begin phase)
+    size_t set_begin();
+    // Set the struct value (end phase)
+    void set_end(size_t fbe_begin);
+
+    // Set the struct value
+    void set(const ::proto::PremiumAccount& fbe_value) noexcept;
+    // Set the struct fields values
+    void set_fields(const ::proto::PremiumAccount& fbe_value) noexcept;
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+
+public:
+    FieldModel<int32_t> id;
+    FieldModel<stdb::memory::string> name;
+    FieldModel<stdb::memory::string> info;
+    FieldModel<::proto::Balance> private_wallet;
+    FieldModelVector<::proto::Order> private_orders;
+    FieldModel<::proto::State> private_state;
+};
+
+namespace proto {
+
+// Fast Binary Encoding PremiumAccount model
+class PremiumAccountModel : public FBE::Model
+{
+public:
+    PremiumAccountModel() : model(this->buffer(), 4) {}
+    PremiumAccountModel(const std::shared_ptr<FBEBuffer>& buffer) : FBE::Model(buffer), model(this->buffer(), 4) {}
+
+    // Get the model size
+    size_t fbe_size() const noexcept { return model.fbe_size() + model.fbe_extra(); }
+    // Get the model type
+    static constexpr size_t fbe_type() noexcept { return FieldModel<::proto::PremiumAccount>::fbe_type(); }
+
+    // Check if the struct value is valid
+    bool verify();
+
+    // Create a new model (begin phase)
+    size_t create_begin();
+    // Create a new model (end phase)
+    size_t create_end(size_t fbe_begin);
+
+    // Serialize the struct value
+    size_t serialize(const ::proto::PremiumAccount& value);
+    // Deserialize the struct value
+    size_t deserialize(::proto::PremiumAccount& value) const noexcept;
+
+    // Move to the next struct value
+    void next(size_t prev) noexcept { model.fbe_shift(prev); }
+
+public:
+    FieldModel<::proto::PremiumAccount> model;
+};
+
+} // namespace proto
+
 } // namespace FBE

--- a/proto/proto_pmr.cpp
+++ b/proto/proto_pmr.cpp
@@ -464,4 +464,90 @@ std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const AccountMes
     return stream;
 }
 
+PremiumAccount::PremiumAccount()
+    : id((int32_t)0ll)
+    , name()
+    , info()
+    , private_wallet()
+    , private_orders()
+    , private_state(State::bad)
+{}
+
+PremiumAccount::PremiumAccount([[maybe_unused]] allocator_type alloc)
+    : id((int32_t)0ll)
+    , name(alloc)
+    , info(alloc)
+    , private_wallet(alloc)
+    , private_orders(alloc)
+    , private_state(State::bad)
+{}
+
+PremiumAccount::PremiumAccount(int32_t arg_id, const stdb::memory::arena_string& arg_name, const stdb::memory::arena_string& arg_info, const ::proto_pmr::Balance& arg_private_wallet, const pmr::vector<::proto_pmr::Order>& arg_private_orders, const ::proto_pmr::State& arg_private_state)
+    : id(arg_id)
+    , name(arg_name)
+    , info(arg_info)
+    , private_wallet(arg_private_wallet)
+    , private_orders(arg_private_orders)
+    , private_state(arg_private_state)
+{}
+
+bool PremiumAccount::operator==([[maybe_unused]] const PremiumAccount& other) const noexcept
+{
+    return (
+        (id == other.id)
+        && (name == other.name)
+        && (info == other.info)
+        && (private_wallet == other.private_wallet)
+        && (private_orders == other.private_orders)
+        && (private_state == other.private_state)
+        );
+}
+
+bool PremiumAccount::operator<([[maybe_unused]] const PremiumAccount& other) const noexcept
+{
+    if (id < other.id)
+        return true;
+    if (other.id < id)
+        return false;
+    return false;
+}
+
+std::string PremiumAccount::string() const
+{
+    std::stringstream ss; ss << *this; return ss.str();
+}
+
+void PremiumAccount::swap([[maybe_unused]] PremiumAccount& other) noexcept
+{
+    using std::swap;
+    swap(id, other.id);
+    swap(name, other.name);
+    swap(info, other.info);
+    swap(private_wallet, other.private_wallet);
+    swap(private_orders, other.private_orders);
+    swap(private_state, other.private_state);
+}
+
+std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const PremiumAccount& value)
+{
+    stream << "PremiumAccount(";
+    stream << "id="; stream << value.id;
+    stream << ",name="; stream << "\"" << value.name << "\"";
+    stream << ",info="; stream << "\"" << value.info << "\"";
+    stream << ",private_wallet="; stream << value.private_wallet;
+    {
+        bool first = true;
+        stream << ",private_orders=[" << value.private_orders.size() << "][";
+        for (const auto& it : value.private_orders)
+        {
+            stream << std::string(first ? "" : ",") << it;
+            first = false;
+        }
+        stream << "]";
+    }
+    stream << ",private_state="; stream << value.private_state;
+    stream << ")";
+    return stream;
+}
+
 } // namespace proto_pmr

--- a/proto/proto_pmr.h
+++ b/proto/proto_pmr.h
@@ -441,4 +441,60 @@ struct std::hash<proto_pmr::AccountMessage>
 
 namespace proto_pmr {
 
+struct PremiumAccount
+{
+    ArenaManagedCreateOnlyTag;
+
+    int32_t id;
+    stdb::memory::arena_string name;
+    stdb::memory::arena_string info;
+    ::proto_pmr::Balance private_wallet;
+    pmr::vector<::proto_pmr::Order> private_orders;
+    ::proto_pmr::State private_state;
+
+    size_t fbe_type() const noexcept { return 5; }
+
+    PremiumAccount();
+    explicit PremiumAccount(allocator_type alloc);
+    PremiumAccount(int32_t arg_id, const stdb::memory::arena_string& arg_name, const stdb::memory::arena_string& arg_info, const ::proto_pmr::Balance& arg_private_wallet, const pmr::vector<::proto_pmr::Order>& arg_private_orders, const ::proto_pmr::State& arg_private_state);
+    PremiumAccount(const PremiumAccount& other) = default;
+    PremiumAccount(PremiumAccount&& other) = default;
+    ~PremiumAccount() = default;
+
+    PremiumAccount& operator=(const PremiumAccount& other) = default;
+    PremiumAccount& operator=(PremiumAccount&& other) = default;
+
+    bool operator==(const PremiumAccount& other) const noexcept;
+    bool operator!=(const PremiumAccount& other) const noexcept { return !operator==(other); }
+    bool operator<(const PremiumAccount& other) const noexcept;
+    bool operator<=(const PremiumAccount& other) const noexcept { return operator<(other) || operator==(other); }
+    bool operator>(const PremiumAccount& other) const noexcept { return !operator<=(other); }
+    bool operator>=(const PremiumAccount& other) const noexcept { return !operator<(other); }
+
+    std::string string() const;
+
+    friend std::ostream& operator<<(std::ostream& stream, [[maybe_unused]] const PremiumAccount& value);
+
+    void swap(PremiumAccount& other) noexcept;
+    friend void swap(PremiumAccount& value1, PremiumAccount& value2) noexcept { value1.swap(value2); }
+};
+
+} // namespace proto_pmr
+
+template<>
+struct std::hash<proto_pmr::PremiumAccount>
+{
+    typedef proto_pmr::PremiumAccount argument_type;
+    typedef size_t result_type;
+
+    result_type operator() ([[maybe_unused]] const argument_type& value) const
+    {
+        result_type result = 17;
+        result = result * 31 + std::hash<decltype(value.id)>()(value.id);
+        return result;
+    }
+};
+
+namespace proto_pmr {
+
 } // namespace proto_pmr

--- a/proto/proto_pmr_models.cpp
+++ b/proto/proto_pmr_models.cpp
@@ -1627,4 +1627,290 @@ size_t AccountMessageModel::deserialize(::proto_pmr::AccountMessage& value) cons
 
 } // namespace proto_pmr
 
+FieldModel<::proto_pmr::PremiumAccount>::FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset)
+    , id(buffer, 4 + 4)
+    , name(buffer, id.fbe_offset() + id.fbe_size())
+    , info(buffer, name.fbe_offset() + name.fbe_size())
+    , private_wallet(buffer, info.fbe_offset() + info.fbe_size())
+    , private_orders(buffer, private_wallet.fbe_offset() + private_wallet.fbe_size())
+    , private_state(buffer, private_orders.fbe_offset() + private_orders.fbe_size())
+{}
+
+size_t FieldModel<::proto_pmr::PremiumAccount>::fbe_body() const noexcept
+{
+    size_t fbe_result = 4 + 4
+        + id.fbe_size()
+        + name.fbe_size()
+        + info.fbe_size()
+        + private_wallet.fbe_size()
+        + private_orders.fbe_size()
+        + private_state.fbe_size()
+        ;
+    return fbe_result;
+}
+
+size_t FieldModel<::proto_pmr::PremiumAccount>::fbe_extra() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4) > _buffer.size()))
+        return 0;
+
+    _buffer.shift(fbe_struct_offset);
+
+    size_t fbe_result = fbe_body()
+        + id.fbe_extra()
+        + name.fbe_extra()
+        + info.fbe_extra()
+        + private_wallet.fbe_extra()
+        + private_orders.fbe_extra()
+        + private_state.fbe_extra()
+        ;
+
+    _buffer.unshift(fbe_struct_offset);
+
+    return fbe_result;
+}
+
+bool FieldModel<::proto_pmr::PremiumAccount>::verify(bool fbe_verify_type) const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return true;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4 + 4) > _buffer.size()))
+        return false;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset);
+    if (fbe_struct_size < (4 + 4))
+        return false;
+
+    uint32_t fbe_struct_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset + 4);
+    if (fbe_verify_type && (fbe_struct_type != fbe_type()))
+        return false;
+
+    _buffer.shift(fbe_struct_offset);
+    bool fbe_result = verify_fields(fbe_struct_size);
+    _buffer.unshift(fbe_struct_offset);
+    return fbe_result;
+}
+
+bool FieldModel<::proto_pmr::PremiumAccount>::verify_fields([[maybe_unused]] size_t fbe_struct_size) const noexcept
+{
+    size_t fbe_current_size = 4 + 4;
+
+    if ((fbe_current_size + id.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!id.verify())
+        return false;
+    fbe_current_size += id.fbe_size();
+
+    if ((fbe_current_size + name.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!name.verify())
+        return false;
+    fbe_current_size += name.fbe_size();
+
+    if ((fbe_current_size + info.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!info.verify())
+        return false;
+    fbe_current_size += info.fbe_size();
+
+    if ((fbe_current_size + private_wallet.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_wallet.verify())
+        return false;
+    fbe_current_size += private_wallet.fbe_size();
+
+    if ((fbe_current_size + private_orders.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_orders.verify())
+        return false;
+    fbe_current_size += private_orders.fbe_size();
+
+    if ((fbe_current_size + private_state.fbe_size()) > fbe_struct_size)
+        return true;
+    if (!private_state.verify())
+        return false;
+    fbe_current_size += private_state.fbe_size();
+
+    return true;
+}
+
+size_t FieldModel<::proto_pmr::PremiumAccount>::get_begin() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    assert(((fbe_struct_offset > 0) && ((_buffer.offset() + fbe_struct_offset + 4 + 4) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + 4 + 4) > _buffer.size()))
+        return 0;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset);
+    assert((fbe_struct_size >= (4 + 4)) && "Model is broken!");
+    if (fbe_struct_size < (4 + 4))
+        return 0;
+
+    _buffer.shift(fbe_struct_offset);
+    return fbe_struct_offset;
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::get_end(size_t fbe_begin) const noexcept
+{
+    _buffer.unshift(fbe_begin);
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::get(::proto_pmr::PremiumAccount& fbe_value) const noexcept
+{
+    size_t fbe_begin = get_begin();
+    if (fbe_begin == 0)
+        return;
+
+    uint32_t fbe_struct_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset());
+    get_fields(fbe_value, fbe_struct_size);
+    get_end(fbe_begin);
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::get_fields([[maybe_unused]] ::proto_pmr::PremiumAccount& fbe_value, [[maybe_unused]] size_t fbe_struct_size) const noexcept
+{
+    size_t fbe_current_size = 4 + 4;
+
+    if ((fbe_current_size + id.fbe_size()) <= fbe_struct_size)
+        id.get(fbe_value.id);
+    else
+        fbe_value.id = (int32_t)0ll;
+    fbe_current_size += id.fbe_size();
+
+    if ((fbe_current_size + name.fbe_size()) <= fbe_struct_size)
+        name.get(fbe_value.name);
+    else
+        fbe_value.name = "";
+    fbe_current_size += name.fbe_size();
+
+    if ((fbe_current_size + info.fbe_size()) <= fbe_struct_size)
+        info.get(fbe_value.info);
+    else
+        fbe_value.info = "";
+    fbe_current_size += info.fbe_size();
+
+    if ((fbe_current_size + private_wallet.fbe_size()) <= fbe_struct_size)
+        private_wallet.get(fbe_value.private_wallet);
+    else
+        fbe_value.private_wallet = ::proto_pmr::Balance();
+    fbe_current_size += private_wallet.fbe_size();
+
+    if ((fbe_current_size + private_orders.fbe_size()) <= fbe_struct_size)
+        private_orders.get(fbe_value.private_orders);
+    else
+        fbe_value.private_orders.clear();
+    fbe_current_size += private_orders.fbe_size();
+
+    if ((fbe_current_size + private_state.fbe_size()) <= fbe_struct_size)
+        private_state.get(fbe_value.private_state, State::bad);
+    else
+        fbe_value.private_state = State::bad;
+    fbe_current_size += private_state.fbe_size();
+}
+
+size_t FieldModel<::proto_pmr::PremiumAccount>::set_begin()
+{
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_struct_size = (uint32_t)fbe_body();
+    uint32_t fbe_struct_offset = (uint32_t)(_buffer.allocate(fbe_struct_size) - _buffer.offset());
+    assert(((fbe_struct_offset > 0) && ((_buffer.offset() + fbe_struct_offset + fbe_struct_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_struct_offset == 0) || ((_buffer.offset() + fbe_struct_offset + fbe_struct_size) > _buffer.size()))
+        return 0;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_struct_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset, fbe_struct_size);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_struct_offset + 4, (uint32_t)fbe_type());
+
+    _buffer.shift(fbe_struct_offset);
+    return fbe_struct_offset;
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::set_end(size_t fbe_begin)
+{
+    _buffer.unshift(fbe_begin);
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::set(const ::proto_pmr::PremiumAccount& fbe_value) noexcept
+{
+    size_t fbe_begin = set_begin();
+    if (fbe_begin == 0)
+        return;
+
+    set_fields(fbe_value);
+    set_end(fbe_begin);
+}
+
+void FieldModel<::proto_pmr::PremiumAccount>::set_fields([[maybe_unused]] const ::proto_pmr::PremiumAccount& fbe_value) noexcept
+{
+    id.set(fbe_value.id);
+    name.set(fbe_value.name);
+    info.set(fbe_value.info);
+    private_wallet.set(fbe_value.private_wallet);
+    private_orders.set(fbe_value.private_orders);
+    private_state.set(fbe_value.private_state);
+}
+
+namespace proto_pmr {
+
+bool PremiumAccountModel::verify()
+{
+    if ((this->buffer().offset() + model.fbe_offset() - 4) > this->buffer().size())
+        return false;
+
+    uint32_t fbe_full_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4);
+    if (fbe_full_size < model.fbe_size())
+        return false;
+
+    return model.verify();
+}
+
+size_t PremiumAccountModel::create_begin()
+{
+    size_t fbe_begin = this->buffer().allocate(4 + model.fbe_size());
+    return fbe_begin;
+}
+
+size_t PremiumAccountModel::create_end(size_t fbe_begin)
+{
+    size_t fbe_end = this->buffer().size();
+    uint32_t fbe_full_size = (uint32_t)(fbe_end - fbe_begin);
+    unaligned_store<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4, fbe_full_size);
+    return fbe_full_size;
+}
+
+size_t PremiumAccountModel::serialize(const ::proto_pmr::PremiumAccount& value)
+{
+    size_t fbe_begin = create_begin();
+    model.set(value);
+    size_t fbe_full_size = create_end(fbe_begin);
+    return fbe_full_size;
+}
+
+size_t PremiumAccountModel::deserialize(::proto_pmr::PremiumAccount& value) const noexcept
+{
+    if ((this->buffer().offset() + model.fbe_offset() - 4) > this->buffer().size())
+        return 0;
+
+    uint32_t fbe_full_size = unaligned_load<uint32_t>(this->buffer().data() + this->buffer().offset() + model.fbe_offset() - 4);
+    assert((fbe_full_size >= model.fbe_size()) && "Model is broken!");
+    if (fbe_full_size < model.fbe_size())
+        return 0;
+
+    model.get(value);
+    return fbe_full_size;
+}
+
+} // namespace proto_pmr
+
 } // namespace FBE

--- a/proto/proto_pmr_models.h
+++ b/proto/proto_pmr_models.h
@@ -704,4 +704,101 @@ public:
 
 } // namespace proto_pmr
 
+// Fast Binary Encoding ::proto_pmr::PremiumAccount field model
+template <>
+class FieldModel<::proto_pmr::PremiumAccount>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept;
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field body size
+    size_t fbe_body() const noexcept;
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+    // Get the field type
+    static constexpr size_t fbe_type() noexcept { return 5; }
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the struct value is valid
+    bool verify(bool fbe_verify_type = true) const noexcept;
+    // Check if the struct fields are valid
+    bool verify_fields(size_t fbe_struct_size) const noexcept;
+
+    // Get the struct value (begin phase)
+    size_t get_begin() const noexcept;
+    // Get the struct value (end phase)
+    void get_end(size_t fbe_begin) const noexcept;
+
+    // Get the struct value
+    void get(::proto_pmr::PremiumAccount& fbe_value) const noexcept;
+    // Get the struct fields values
+    void get_fields(::proto_pmr::PremiumAccount& fbe_value, size_t fbe_struct_size) const noexcept;
+
+    // Set the struct value (begin phase)
+    size_t set_begin();
+    // Set the struct value (end phase)
+    void set_end(size_t fbe_begin);
+
+    // Set the struct value
+    void set(const ::proto_pmr::PremiumAccount& fbe_value) noexcept;
+    // Set the struct fields values
+    void set_fields(const ::proto_pmr::PremiumAccount& fbe_value) noexcept;
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+
+public:
+    FieldModel<int32_t> id;
+    FieldModel<stdb::memory::arena_string> name;
+    FieldModel<stdb::memory::arena_string> info;
+    FieldModel<::proto_pmr::Balance> private_wallet;
+    FieldModelVector<::proto_pmr::Order> private_orders;
+    FieldModel<::proto_pmr::State> private_state;
+};
+
+namespace proto_pmr {
+
+// Fast Binary Encoding PremiumAccount model
+class PremiumAccountModel : public FBE::Model
+{
+public:
+    PremiumAccountModel() : model(this->buffer(), 4) {}
+    PremiumAccountModel(const std::shared_ptr<FBEBuffer>& buffer) : FBE::Model(buffer), model(this->buffer(), 4) {}
+
+    // Get the model size
+    size_t fbe_size() const noexcept { return model.fbe_size() + model.fbe_extra(); }
+    // Get the model type
+    static constexpr size_t fbe_type() noexcept { return FieldModel<::proto_pmr::PremiumAccount>::fbe_type(); }
+
+    // Check if the struct value is valid
+    bool verify();
+
+    // Create a new model (begin phase)
+    size_t create_begin();
+    // Create a new model (end phase)
+    size_t create_end(size_t fbe_begin);
+
+    // Serialize the struct value
+    size_t serialize(const ::proto_pmr::PremiumAccount& value);
+    // Deserialize the struct value
+    size_t deserialize(::proto_pmr::PremiumAccount& value) const noexcept;
+
+    // Move to the next struct value
+    void next(size_t prev) noexcept { model.fbe_shift(prev); }
+
+public:
+    FieldModel<::proto_pmr::PremiumAccount> model;
+};
+
+} // namespace proto_pmr
+
 } // namespace FBE

--- a/tests/test_serialization_json.cpp
+++ b/tests/test_serialization_json.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Serialization (JSON): domain", "[FBE]")
     rapidjson::Document json;
     json.Parse(R"JSON({"id":1,"name":"Test","state":6,"wallet":{"currency":"USD","amount":1000.0},"asset":{"currency":"EUR","amount":100.0},"orders":[{"id":1,"symbol":"EURUSD","side":0,"type":0,"price":1.23456,"volume":1000.0},{"id":2,"symbol":"EURUSD","side":1,"type":1,"price":1.0,"volume":100.0},{"id":3,"symbol":"EURUSD","side":0,"type":2,"price":1.5,"volume":10.0}]})JSON");
 
-    // Create a new account from the source JSON string
+    // Create a new account from the source JSON string 
     proto::Account account1;
     REQUIRE(FBE::JSON::from_json(json, account1));
 
@@ -66,6 +66,41 @@ TEST_CASE("Serialization (JSON): domain", "[FBE]")
     REQUIRE(account2.orders[2].type == proto::OrderType::stop);
     REQUIRE(account2.orders[2].price == 1.5);
     REQUIRE(account2.orders[2].volume == 10.0);
+    REQUIRE(account1 == account2);
+}
+
+TEST_CASE("Serialization (JSON): omit fields", "[FBE]")
+{
+    // Define a source JSON string
+    rapidjson::Document json;
+    json.Parse(R"JSON({"id":1,"name":"Test"})JSON");
+
+    // Create a new account from the source JSON string 
+    proto::PremiumAccount account1;
+    REQUIRE(FBE::JSON::from_json(json, account1));
+
+    // Serialize the account to the JSON stream
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    REQUIRE(FBE::JSON::to_json(writer, account1));
+
+    // Check the serialized JSON size
+    REQUIRE(buffer.GetSize() > 0);
+
+    // Parse the JSON document
+    json.Parse(buffer.GetString());
+
+    // Deserialize the account from the JSON stream
+    proto::PremiumAccount account2;
+    REQUIRE(FBE::JSON::from_json(json, account2));
+
+    REQUIRE(account2.id == 1);
+    REQUIRE(account2.name == "Test");
+    REQUIRE(account2.info == "");
+    REQUIRE(account2.private_wallet.amount == 0);
+    REQUIRE(account2.private_wallet.currency == "");
+    REQUIRE(account2.private_orders.empty());
+    REQUIRE(account2.private_state == proto::State::bad);
     REQUIRE(account1 == account2);
 }
 


### PR DESCRIPTION
1.  from_json support non-existence fields in json str.
2. Suppress UB errors caused by system-installed rapidjson by using rapidjson imported via git submodule
FIX below errors.

/usr/include/rapidjson/internal/stack.h:117:13: runtime error: applying non-zero offset 16 to null pointer SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/include/rapidjson/internal/stack.h:117:13 in /usr/include/rapidjson/internal/stack.h:117:13: runtime error: applying non-zero offset 1 to null pointer SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/include/rapidjson/internal/stack.h:117:13 in /usr/include/rapidjson/internal/stack.h:117:13: runtime error: applying non-zero offset 16 to null pointer SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/include/rapidjson/internal/stack.h:117:13 in