### PR TITLE
fix incompatible, seastar::sstring missing assign

### DIFF
--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -6371,7 +6371,11 @@ struct ValueReader<TJson, FBEString>
             return false;
 
         // Save the value
+        #if defined(USING_SEASTAR_STRING)
+        value = json.GetString();
+        #else
         value.assign(json.GetString(), (size_t)json.GetStringLength());
+        #endif
         return true;
     }
 };


### PR DESCRIPTION
for `seastar::sstring`, using `operator=` while others using `assign`