### PR TITLE
fix memcpy with null

### DIFF
--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -2093,7 +2093,8 @@ void FieldModel<pmr_buffer_t>::set(const void* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_bytes_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_bytes_offset, fbe_bytes_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_bytes_offset + 4), data, fbe_bytes_size);
+    if (fbe_bytes_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_bytes_offset + 4), data, fbe_bytes_size);
 }
 )CODE";
     }
@@ -2346,8 +2347,8 @@ void FieldModel<FBEString>::set(const char* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
 }
 
 void FieldModel<FBEString>::set(const FBEString& value)
@@ -2365,7 +2366,8 @@ void FieldModel<FBEString>::set(const FBEString& value)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
 }
 )CODE";
     }
@@ -2496,8 +2498,8 @@ void FieldModel<ArenaString>::set(const char* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
 }
 
 void FieldModel<ArenaString>::set(const ArenaString& value)
@@ -2515,7 +2517,8 @@ void FieldModel<ArenaString>::set(const ArenaString& value)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
 }
 )CODE";
     }
@@ -4251,7 +4254,8 @@ size_t FinalModel<buffer_t>::set(const void* data, size_t size)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_bytes_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_bytes_size);
+    if (fbe_bytes_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_bytes_size);
     return 4 + fbe_bytes_size;
 }
 )CODE";
@@ -4384,7 +4388,8 @@ size_t FinalModel<std::string>::set(const char* data, size_t size)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_string_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_string_size);
     return 4 + fbe_string_size;
 }
 
@@ -4401,7 +4406,8 @@ size_t FinalModel<std::string>::set(const std::string& value)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_string_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), value.data(), fbe_string_size);
     return 4 + fbe_string_size;
 }
 )CODE";

--- a/proto/fbe_final_models.cpp
+++ b/proto/fbe_final_models.cpp
@@ -344,7 +344,8 @@ size_t FinalModel<buffer_t>::set(const void* data, size_t size)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_bytes_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_bytes_size);
+    if (fbe_bytes_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_bytes_size);
     return 4 + fbe_bytes_size;
 }
 
@@ -414,7 +415,8 @@ size_t FinalModel<std::string>::set(const char* data, size_t size)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_string_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), data, fbe_string_size);
     return 4 + fbe_string_size;
 }
 
@@ -431,7 +433,8 @@ size_t FinalModel<std::string>::set(const std::string& value)
 
     *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_string_size;
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_offset() + 4), value.data(), fbe_string_size);
     return 4 + fbe_string_size;
 }
 

--- a/proto/fbe_json.h
+++ b/proto/fbe_json.h
@@ -803,7 +803,11 @@ struct ValueReader<TJson, FBEString>
             return false;
 
         // Save the value
+        #if defined(USING_SEASTAR_STRING)
+        value = json.GetString();
+        #else
         value.assign(json.GetString(), (size_t)json.GetStringLength());
+        #endif
         return true;
     }
 };

--- a/proto/fbe_models.cpp
+++ b/proto/fbe_models.cpp
@@ -474,7 +474,8 @@ void FieldModel<pmr_buffer_t>::set(const void* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_bytes_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_bytes_offset, fbe_bytes_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_bytes_offset + 4), data, fbe_bytes_size);
+    if (fbe_bytes_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_bytes_offset + 4), data, fbe_bytes_size);
 }
 
 size_t FieldModel<FBEString>::fbe_extra() const noexcept
@@ -613,8 +614,8 @@ void FieldModel<FBEString>::set(const char* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
 }
 
 void FieldModel<FBEString>::set(const FBEString& value)
@@ -632,7 +633,8 @@ void FieldModel<FBEString>::set(const FBEString& value)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
 }
 
 size_t FieldModel<ArenaString>::fbe_extra() const noexcept
@@ -759,8 +761,8 @@ void FieldModel<ArenaString>::set(const char* data, size_t size)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
 }
 
 void FieldModel<ArenaString>::set(const ArenaString& value)
@@ -778,7 +780,8 @@ void FieldModel<ArenaString>::set(const ArenaString& value)
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
     unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
 
-    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+    if (fbe_string_size > 0)
+        memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
 }
 
 } // namespace FBE


### PR DESCRIPTION
FIX memcpy with nullptr which is declared never to be null
```
fbe_models.cpp:477:79: runtime error: null pointer passed as argument 2, which is declared to never be null
```